### PR TITLE
[TG Mirror] Fix white ship sometimes overlapping other ruins [MDB IGNORE]

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm
@@ -834,7 +834,7 @@ a
 a
 a
 a
-b
+a
 a
 a
 a
@@ -1244,7 +1244,7 @@ a
 a
 a
 a
-a
+b
 a
 a
 a

--- a/code/modules/shuttle/stationary_port/port_types.dm
+++ b/code/modules/shuttle/stationary_port/port_types.dm
@@ -80,8 +80,8 @@
 	name = "Deep Space"
 	shuttle_id = "whiteship_away"
 	height = 45 //Width and height need to remain in sync with the size of whiteshipdock.dmm, otherwise we'll get overflow
-	width = 44
-	dheight = 18
+	width = 45
+	dheight = 14
 	dwidth = 18
 	dir = 2
 	shuttlekeys = list(


### PR DESCRIPTION
Original PR: 93491
-----

## About The Pull Request

Moves the docking port in the `whiteshipdock.dmm` ruin closer to the top center instead of the bottom left where it currently is, fixes the `width` being off by one, fixes `dwith` and `dheight` being wrong. 

What happened here is `dwidth` and `dheight` are supposed to be counted from the top right instead of the bottom left here, so while the docking port was placed in the bottom left, the code said it was in the top right and so no runtimes were thrown when loading a shuttle that actually didn't fit. But most of the white ship templates _didn't_ fit, meaning they'd jut outside the boundaries of the ruin, and if another ruin was placed next to it it'd overwrite parts of them.

I tested all of the white ship templates with these new values and they all fit well.

## Why It's Good For The Game

<img width="1262" height="997" alt="image" src="https://github.com/user-attachments/assets/509feef8-4ff9-4483-ae92-6886f4592e54" />
Bad!

## Changelog
:cl:
fix: fixed white ship sometimes loading partially inside other ruins
/:cl:
