### PR TITLE
[TG Mirror] fix moon robes runtime + make adjustDamageType be handled by moon robes [MDB IGNORE]

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -54,6 +54,1024 @@
 	// Our hood gains the heretic_focus element.
 	. += span_notice("Allows you to cast heretic spells while the hood is up.")
 
+<<<<<<< HEAD
+=======
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch
+	name = "ominous hood"
+	icon = 'icons/obj/clothing/head/helmet.dmi'
+	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
+	icon_state = "eldritch"
+	desc = "A torn, dust-caked hood. Strange eyes line the inside."
+	flags_inv = HIDEMASK | HIDEEARS | HIDEEYES | HIDEFACE | HIDEHAIR | HIDEFACIALHAIR | HIDESNOUT
+	flags_cover = HEADCOVERSEYES | PEPPERPROOF
+	flash_protect = FLASH_PROTECTION_WELDER_HYPER_SENSITIVE
+	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	clothing_flags = THICKMATERIAL | PLASMAMAN_PREVENT_IGNITION | SNUG_FIT
+	armor_type = /datum/armor/eldritch_armor
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/heretic_focus)
+
+/datum/armor/eldritch_armor
+	melee = 50
+	bullet = 50
+	laser = 50
+	energy = 50
+	bomb = 35
+	bio = 20
+	fire = 20
+	acid = 20
+	wound = 20
+
+//---- Path-Specific Eldritch Robes, First is robes, then is hood
+
+// Ash
+// Prevents fire from decaying while worn, also passively generates fire via the toggle
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/ash
+	name = "\improper Scorched Mantle"
+	desc = "Left to burn to tatters, what remains is naught but a blackened echo of the mantle of the Watch. \
+		Yet the soot-choked folds turn blade and flame from the form within. A brief reprieve before its gaze turns inwards."
+	icon_state = "ash_armor"
+	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch/ash
+	armor_type = /datum/armor/eldritch_armor/ash
+	flags_inv = HIDEBELT
+	body_parts_covered = FULL_BODY
+	heat_protection = FULL_BODY
+	max_heat_protection_temperature = 50000
+	cold_protection = FULL_BODY
+	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
+	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF | LAVA_PROOF | FREEZE_PROOF
+	actions_types = list(/datum/action/item_action/toggle/flames)
+	/// If our robes are actively generating flames
+	var/flame_generation = FALSE
+	/// Cooldown before our robes will create new flames
+	COOLDOWN_DECLARE(flame_creation)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/ash/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/radiation_protected_clothing)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/ash/on_robes_gained(mob/living/user)
+	if(!isliving(user))
+		return
+	var/mob/living/wearer = user
+	wearer.fire_stack_decay_rate = 0
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/ash/on_robes_lost(mob/living/user)
+	if(!isliving(user))
+		return
+	var/mob/living/wearer = user
+	wearer.fire_stack_decay_rate = initial(wearer.fire_stack_decay_rate)
+	if(flame_generation)
+		toggle_flames(wearer)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/ash/robes_side_effect(mob/living/user)
+	if(!iscarbon(user))
+		return
+	var/mob/living/carbon/victim = user
+	var/iteration = 0
+	for(var/obj/item/bodypart/limb as anything in victim.bodyparts)
+		if(istype(limb, /obj/item/bodypart/head) || istype(limb, /obj/item/bodypart/chest))
+			continue
+		iteration++
+		addtimer(CALLBACK(src, PROC_REF(burn_limbs), limb), 1 SECONDS * iteration)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/ash/proc/burn_limbs(obj/item/bodypart/limb)
+	if(QDELETED(limb) || !limb.owner || !is_equipped(limb.owner))
+		return
+	limb.dismember(BURN)
+
+/datum/action/item_action/toggle/flames
+	button_icon = 'icons/effects/magic.dmi'
+	button_icon_state = "fireball"
+
+/datum/action/item_action/toggle/flames/do_effect(trigger_flags)
+	var/obj/item/clothing/suit/hooded/cultrobes/eldritch/ash/item_target = target
+	if(!item_target || !istype(item_target))
+		return FALSE
+	item_target.toggle_flames(owner)
+
+/// Starts/Stops the passive generation of fire stacks on our wearer
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/ash/proc/toggle_flames(mob/living/user)
+	flame_generation = !flame_generation
+
+	if(flame_generation)
+		START_PROCESSING(SSobj, src)
+	else
+		user.extinguish()
+		STOP_PROCESSING(SSobj, src)
+
+	user.balloon_alert(user, flame_generation ? "enabled" : "disabled")
+	user.fire_stack_decay_rate = flame_generation ? 0 : initial(user.fire_stack_decay_rate)
+	// Extinguishes the wearer after they disable the flames
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/ash/process(seconds_per_tick)
+	if(!COOLDOWN_FINISHED(src, flame_creation))
+		return
+	var/mob/living/wearer = loc
+	if(!isliving(wearer))
+		STOP_PROCESSING(SSobj, src)
+		flame_generation = FALSE
+		return
+	COOLDOWN_START(src, flame_creation, 5 SECONDS)
+	wearer.adjust_fire_stacks(1)
+	wearer.ignite_mob(TRUE)
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/ash
+	name = "\improper Scorched Mantle"
+	desc = "Left to burn to tatters, what remains is naught but a blackened echo of the mantle of the Watch. \
+		Yet the soot-choked folds turn blade and flame from the form within. A brief reprieve before its gaze turns inwards."
+	icon_state = "ash_armor"
+	armor_type = /datum/armor/eldritch_armor/ash
+
+/datum/armor/eldritch_armor/ash
+	melee = 40
+	bullet = 60
+	laser = 50
+	energy = 50
+	bomb = 100
+	bio = 20
+	fire = 100
+	acid = 20
+	wound = 20
+
+// Blade
+// Is shock-proof and gives you baton resistance
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/blade
+	name = "\improper Shattered Panoply"
+	desc = "The sharpened edges of this ancient suit of armor assert a revelation known to aspirants of battle; \
+			a true warrior can not be distinguished from the blade they wield."
+	icon_state = "blade_armor"
+	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch/blade
+	armor_type = /datum/armor/eldritch_armor/blade
+	siemens_coefficient = 0
+	var/murdering_with_blades = FALSE
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/blade/on_robes_gained(mob/living/user)
+	. = ..()
+	user.add_traits(list(TRAIT_SHOCKIMMUNE, TRAIT_BATON_RESISTANCE), REF(src))
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/blade/on_robes_lost(mob/user, obj/item/clothing/suit/hooded/cultrobes/eldritch/robes)
+	. = ..()
+	if(.)
+		return
+	user.remove_traits(list(TRAIT_SHOCKIMMUNE, TRAIT_BATON_RESISTANCE), REF(src))
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/blade/robes_side_effect(mob/living/user)
+	INVOKE_ASYNC(src, PROC_REF(start_throwing_blades), user)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/blade/proc/start_throwing_blades(mob/living/target)
+	if(murdering_with_blades)
+		return
+	murdering_with_blades = TRUE
+
+	var/delay = 2 SECONDS
+	var/knives = 100
+	for(var/knife in 1 to knives)
+		if(!should_keep_cutting(target))
+			break
+		addtimer(CALLBACK(src, PROC_REF(cut_em_good), target), delay * knife)
+		delay = max(0.5 SECONDS, delay - 0.1 SECONDS)
+
+	murdering_with_blades = FALSE
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/blade/proc/should_keep_cutting(mob/living/target)
+	if(target.stat == DEAD || !is_equipped(target))
+		return FALSE
+	return TRUE
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/blade/proc/cut_em_good(mob/living/target)
+	if(!should_keep_cutting(target))
+		return
+	var/list/turf/valid_turfs = get_blade_turfs(get_turf(target))
+	if(!length(valid_turfs))
+		var/mob/living/carbon/carbon_target = target
+		if(iscarbon(target))
+			var/obj/item/bodypart/limb = pick(carbon_target.bodyparts)
+			limb.force_wound_upwards(/datum/wound/slash/flesh/severe)
+		return
+	throw_blade(pick(valid_turfs), target)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/blade/proc/get_blade_turfs(mob/user)
+	var/list/turfs_around_us = get_perimeter(user, 4)
+	var/list/valid_turfs = list()
+	for(var/turf/open/valid_turf in turfs_around_us)
+		if(!valid_turf.is_blocked_turf() && get_angle(valid_turf, user) != 180)
+			valid_turfs |= valid_turf
+	return valid_turfs
+
+/obj/item/knife/kitchen/magic
+	icon = 'icons/effects/eldritch.dmi'
+	icon_state = "dio_knife"
+	name = "magic knife"
+	throwforce = 15
+	// most importantly, this ignores shields
+	armour_penetration = 200
+	pass_flags = ALL
+
+/obj/item/knife/kitchen/magic/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/movetype_handler)
+	add_traits(list(TRAIT_MOVE_PHASING, TRAIT_MOVE_FLOATING, TRAIT_UNCATCHABLE), INNATE_TRAIT)
+	add_filter("dio_knife", 2, list("type" = "outline", "color" = "#ececff", "size" = 1))
+	set_embed(/datum/embedding/magic_knife)
+
+/obj/item/knife/kitchen/magic/get_demolition_modifier(obj/target)
+	if(!ismob(target))
+		return 100
+	return ..()
+
+/datum/embedding/magic_knife
+
+	embed_chance = 150
+	fall_chance = 0
+	impact_pain_mult = 0
+	ignore_throwspeed_threshold = TRUE
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/blade/proc/throw_blade(turf/target_turf, mob/user)
+	var/obj/item/knife/kitchen/magic/knife = new(target_turf)
+	knife.alpha = 0
+	knife.throw_at()
+
+	var/matrix/transform = matrix(knife.transform)
+	var/angle = get_angle(target_turf, user)
+	transform.Turn(angle)
+	var/appear_delay = 0.5 SECONDS
+	var/throw_delay = 1 SECONDS
+	var/delete_delay = 10 SECONDS
+	addtimer(CALLBACK(knife, TYPE_PROC_REF(/atom/movable, throw_at), user, 50, 5, null, FALSE), throw_delay)
+	animate(knife, transform = transform, time = throw_delay, ANIMATION_PARALLEL)
+	animate(knife, alpha = 255, time = appear_delay, ANIMATION_PARALLEL)
+	animate(alpha = 0, time = delete_delay)
+	QDEL_IN(knife, delete_delay + appear_delay + throw_delay)
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/blade
+	name = "\improper Shattered Panoply"
+	desc = "The sharpened edges of this ancient suit of armor assert a revelation known to aspirants of battle; \
+			a true warrior can not be distinguished from the blade they wield."
+	icon_state = "blade_armor"
+	armor_type = /datum/armor/eldritch_armor/blade
+	siemens_coefficient = 0
+
+/datum/armor/eldritch_armor/blade
+	melee = 50
+	bullet = 50
+	laser = 50
+	energy = 50
+	bomb = 50
+	bio = 50
+	fire = 50
+	acid = 50
+	wound = 50
+
+// Cosmic
+// Allows you to toggle gravity for yourself at will
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/cosmic
+	name = "\improper Starwoven Cloak"
+	desc = "Gleaming gems conjure forth wisps of power, turning about to illuminate the wearer in a dim radiance. \
+			Gazing upon the robe, you cannot help but feel noticed."
+	icon_state = "cosmic_armor"
+	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch/cosmic
+	armor_type = /datum/armor/eldritch_armor/cosmic
+	clothing_flags = THICKMATERIAL | PLASMAMAN_PREVENT_IGNITION | STOPSPRESSUREDAMAGE
+	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
+	actions_types = list(/datum/action/item_action/toggle/gravity)
+	/// If our robes are making us weightless
+	var/weightless_enabled = FALSE
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/cosmic/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/radiation_protected_clothing)
+
+// Removes your antigravity if you lose the robes
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/cosmic/on_robes_lost(mob/user, obj/item/clothing/suit/hooded/cultrobes/eldritch/robes)
+	if(.)
+		return
+	if(weightless_enabled)
+		toggle_gravity(user)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/cosmic/robes_side_effect(mob/living/user)
+	var/obj/item/organ/brain/victim_brain = user.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!victim_brain)
+		return
+
+	victim_brain.gain_trauma(/datum/brain_trauma/magic/stalker/cosmic, TRAUMA_RESILIENCE_MAGIC)
+
+/datum/action/item_action/toggle/gravity
+	button_icon = 'icons/effects/magic.dmi'
+	button_icon_state = "magicm"
+
+/datum/action/item_action/toggle/gravity/do_effect(trigger_flags)
+	var/obj/item/clothing/suit/hooded/cultrobes/eldritch/cosmic/item_target = target
+	if(!item_target || !istype(item_target))
+		return FALSE
+	item_target.toggle_gravity(owner)
+
+/// Gives us free movement in 0 gravity when enabled
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/cosmic/proc/toggle_gravity(mob/living/user)
+	if(!weightless_enabled)
+		user.add_traits(list(TRAIT_NEGATES_GRAVITY, TRAIT_MOVE_FLYING, TRAIT_FREE_HYPERSPACE_MOVEMENT), REF(src))
+		user.balloon_alert(user, "enabled")
+	else
+		user.remove_traits(list(TRAIT_NEGATES_GRAVITY, TRAIT_MOVE_FLYING, TRAIT_FREE_HYPERSPACE_MOVEMENT), REF(src))
+		user.balloon_alert(user, "disabled")
+	weightless_enabled = !weightless_enabled
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/cosmic
+	name = "\improper Starwoven Hood"
+	desc = "Gleaming gems conjure forth wisps of power, turning about to illuminate the wearer in a dim radiance. \
+			Gazing upon the robe, you cannot help but feel noticed."
+	icon_state = "cosmic_armor"
+	armor_type = /datum/armor/eldritch_armor/cosmic
+	clothing_flags = THICKMATERIAL | PLASMAMAN_PREVENT_IGNITION | STOPSPRESSUREDAMAGE
+	cold_protection = HEAD
+	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/cosmic/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/radiation_protected_clothing)
+
+/datum/armor/eldritch_armor/cosmic
+	melee = 20
+	bullet = 30
+	laser = 60
+	energy = 60
+	bomb = 35
+	bio = 20
+	fire = 20
+	acid = 20
+	wound = 20
+
+// Flesh
+// Emits a healing aura that affects any heretic summons (excluding the heretic himself)
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/flesh
+	name = "Writhing Embrace"
+	desc = "A rotten carcass, or perhaps several, twisted into fleshy polyps, knotted intestines and cracked bone. \
+			How one 'wears' this baffles reasonable understanding. It moves when it believes itself unobserved."
+	icon_state = "flesh_armor"
+	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch/flesh
+	armor_type = /datum/armor/eldritch_armor/flesh
+	/// The aura healing component. Used to delete it when taken off.
+	var/datum/component/healing_aura
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/flesh/on_robes_gained(mob/living/user)
+	healing_aura = user.AddComponent( \
+		/datum/component/aura_healing, \
+		range = 15, \
+		brute_heal = 3, \
+		burn_heal = 3, \
+		blood_heal = 3, \
+		suffocation_heal = 3, \
+		stamina_heal = 15, \
+		simple_heal = 3, \
+		requires_visibility = FALSE, \
+		limit_to_trait = TRAIT_HERETIC_SUMMON, \
+		healing_color = COLOR_RED, \
+		self_heal = FALSE, \
+	)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/flesh/on_robes_lost(mob/user, obj/item/clothing/suit/hooded/cultrobes/eldritch/robes)
+	QDEL_NULL(healing_aura)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/flesh/robes_side_effect(mob/living/user)
+	if(!iscarbon(user))
+		return
+	var/mob/living/carbon/victim = user
+	var/iteration = 0
+	for(var/obj/item/bodypart/limb as anything in victim.bodyparts)
+		iteration++
+		addtimer(CALLBACK(limb, TYPE_PROC_REF(/obj/item/bodypart, force_wound_upwards), /datum/wound/slash/flesh/critical), 1 SECONDS * iteration)
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/flesh
+	icon_state = "flesh_armor"
+	armor_type = /datum/armor/eldritch_armor/flesh
+	clothing_traits = list(TRAIT_MEDICAL_HUD)
+
+/datum/armor/eldritch_armor/flesh
+	melee = 70
+	bullet = 40
+	laser = 30
+	energy = 30
+	bomb = 35
+	bio = 100
+	fire = 0
+	acid = 100
+	wound = 20
+
+// Lock
+// Gives you digital camo, silences your footsteps and makes you un-examineable
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/lock
+	name = "Shifting Guise"
+	icon_state = "lock_armor"
+	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch/lock
+	armor_type = /datum/armor/eldritch_armor/lock
+	flags_inv = parent_type::flags_inv | HIDEMUTWINGS
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/lock/on_robes_gained(mob/living/user)
+	user.AddElement(/datum/element/digitalcamo)
+	user.add_traits(list(TRAIT_SILENT_FOOTSTEPS, TRAIT_UNKNOWN_APPEARANCE, TRAIT_UNKNOWN_VOICE), REF(src))
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/lock/on_robes_lost(mob/user, obj/item/clothing/suit/hooded/cultrobes/eldritch/robes)
+	user.RemoveElement(/datum/element/digitalcamo)
+	user.remove_traits(list(TRAIT_SILENT_FOOTSTEPS, TRAIT_UNKNOWN_APPEARANCE, TRAIT_UNKNOWN_VOICE), REF(src))
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/lock/robes_side_effect(mob/living/user)
+	if(!iscarbon(user))
+		return
+	var/mob/living/carbon/victim = user
+	var/list/things = victim.get_equipped_items(ALL)
+	var/turf/our_turf = get_turf(victim)
+	var/list/turf/nearby_turfs = RANGE_TURFS(5, our_turf) - our_turf
+	for(var/obj/item/to_throw in things)
+		if(user.dropItemToGround(to_throw))
+			to_throw.safe_throw_at(pick(nearby_turfs), 2, 1, spin = TRUE)
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/lock
+	icon_state = "lock_armor"
+	armor_type = /datum/armor/eldritch_armor/lock
+
+/datum/armor/eldritch_armor/lock
+	melee = 40
+	bullet = 40
+	laser = 40
+	energy = 40
+	bomb = 40
+	bio = 40
+	fire = 40
+	acid = 40
+	wound = 40
+
+// Moon
+// Converts all damage into brain damage, nullifying the attack in the process
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon
+	name = "\improper Resplendant Regalia"
+	desc = "The confounding nature of this opulent garb turns and twists the sight. \
+			The viewer must come to a chilling revelation; \
+			what they see is as true as any other face."
+	icon_state = "moon_armor"
+	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch/moon
+	armor_type = /datum/armor/eldritch_armor/moon
+	flags_inv = HIDESHOES | HIDEJUMPSUIT | HIDEMUTWINGS
+	clothing_traits = list(
+		TRAIT_HERETIC_AURA_HIDDEN,
+		TRAIT_BATON_RESISTANCE,
+		TRAIT_STUNIMMUNE,
+		TRAIT_NEVER_WOUNDED,
+		TRAIT_PACIFISM,
+		TRAIT_NOHUNGER
+	)
+	/// Hud that gets shown to the wearer, gives a rough estimate of their current brain damage
+	var/atom/movable/screen/moon_health/health_hud
+	/// Boolean if you are brain dead so the sound doesn't spam during the delay
+	var/braindead = FALSE
+	//---- Messages that get sent when someone wearing the moon robes is attacked
+	/// Visible message that nearby people see
+	var/static/list/visible_message_list = list(
+		"%USER seems to hardly register that they have been harmed by %ATTACKER, not even flinching naturally.",
+		"Though wounded, %USER seems oblivious to %ATTACKER.",
+		"You hear %USER laughing. But they have not made a single sound, even when struck by %ATTACKER.",
+	)
+	/// Message sent to the wearer who got attacked
+	var/static/list/self_message_list = list(
+		"Your body ripples as still water freshly disturbed. The sensation is exquisite, and you have %ATTACKER to thank.",
+		"A bell tolls. %ATTACKER has struck the hour and you tick to that tune.",
+		//"You are needed in [area name]. You need to be there. %ATTACKER might want you to stay, but you are needed in [area name].",
+		//"You see %ATTACKER strike a [name of animal]. The face of the beast is a mirror of your own. How strange.",
+		"%ATTACKER bumps you and you spill your tea. It's fine. You've plenty of cups.",
+		"You hear a roaring crash. The waves hit the boat. The is sea vast and dark. You see %ATTACKER striking the water, cursing its master.",
+		"Sequins scatter into the air around %ATTACKER. The sequins...",
+		"You notice that a button has popped off your collar. How did that happen? Maybe %ATTACKER is to blame.",
+		"%ATTACKER isn't very funny, and you're struggling to see the punchline.",
+	)
+	/// Message sent to blind people nearby
+	var/static/list/blind_message_list = list(
+		"You hear echoing laughter.",
+		"You hear a distance chorus.",
+		"You hear the sound of bells and whistles.",
+		"You hear the clack of a tambourine.",
+	)
+	/// List of all signals registered, used for cleanup
+	var/signal_registered = list()
+	/// damage modifier to all incoming damage, which is also converted to brain damage
+	var/damage_modifier = 1.15
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/equipped(mob/user, slot, initial)
+	. = ..()
+	if(!ishuman(user) || !(slot_flags & slot))
+		return
+	var/mob/living/carbon/human/human_user = user
+	// Gives the hud to the wearer, if there's no hud, register the signal to be given on creation
+	if(human_user.hud_used)
+		on_hud_created(human_user)
+	else
+		RegisterSignal(human_user, COMSIG_MOB_HUD_CREATED, PROC_REF(on_hud_created))
+		signal_registered += COMSIG_MOB_HUD_CREATED
+
+	human_user.add_movespeed_mod_immunities(REF(src), /datum/movespeed_modifier/equipment_speedmod)
+	RegisterSignal(human_user, COMSIG_MOB_APPLY_DAMAGE_MODIFIERS, PROC_REF(on_apply_modifiers))
+	signal_registered += COMSIG_MOB_APPLY_DAMAGE_MODIFIERS
+
+	// adjust ignores damage modifiers so we listen to them separately
+	var/list/damage_adjust_signals = list(
+		COMSIG_LIVING_ADJUST_BRUTE_DAMAGE,
+		COMSIG_LIVING_ADJUST_BURN_DAMAGE,
+		COMSIG_LIVING_ADJUST_OXY_DAMAGE,
+		COMSIG_LIVING_ADJUST_TOX_DAMAGE,
+		COMSIG_LIVING_ADJUST_STAMINA_DAMAGE
+	)
+
+	RegisterSignals(human_user, damage_adjust_signals, PROC_REF(adjust_damage))
+	signal_registered += damage_adjust_signals
+
+	RegisterSignal(human_user, COMSIG_LIVING_DEATH, PROC_REF(on_death))
+	signal_registered += COMSIG_LIVING_DEATH
+
+	RegisterSignal(human_user, COMSIG_SEND_ITEM_ATTACK_MESSAGE_CARBON, PROC_REF(item_attack_response))
+	signal_registered += COMSIG_SEND_ITEM_ATTACK_MESSAGE_CARBON
+
+	var/obj/item/organ/brain/our_brain = human_user.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!our_brain)
+		return
+	ADD_TRAIT(our_brain, TRAIT_BRAIN_DAMAGE_NODEATH, REF(src))
+	START_PROCESSING(SSobj, src)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/dropped(mob/living/user)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/wearer = user
+	UnregisterSignal(wearer, signal_registered)
+	signal_registered = list()
+
+	wearer.remove_movespeed_mod_immunities(REF(src), /datum/movespeed_modifier/equipment_speedmod)
+	var/obj/item/organ/brain/our_brain = wearer.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(our_brain)
+		REMOVE_TRAIT(our_brain, TRAIT_BRAIN_DAMAGE_NODEATH, REF(src))
+	braindead = FALSE
+	if(health_hud in user.hud_used.infodisplay)
+		on_hud_remove(user)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/on_apply_modifiers(mob/living/user, damage_mods, damage, damagetype, def_zone, sharpness, attack_direction, attacking_item)
+	SIGNAL_HANDLER
+	if(braindead)
+		return
+	damage_mods += 0
+	handle_damage(user, damage)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/adjust_damage(mob/living/user, type, amount, forced)
+	SIGNAL_HANDLER
+	handle_damage(user, amount)
+	return COMPONENT_IGNORE_CHANGE
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/handle_damage(mob/living/user, damage)
+	user.adjustOrganLoss(ORGAN_SLOT_BRAIN, damage * damage_modifier)
+	check_braindeath(user)
+
+/// Gives the health HUD to the wearer
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/on_hud_created(mob/living/carbon/human/wearer)
+	SIGNAL_HANDLER
+	var/datum/hud/original_hud = wearer.hud_used
+	// Remove the old health elements
+	var/list/to_remove = list(/atom/movable/screen/stamina, /atom/movable/screen/healths, /atom/movable/screen/healthdoll/human)
+	for(var/removing in original_hud.infodisplay)
+		if(is_type_in_list(removing, to_remove))
+			original_hud.infodisplay -= removing
+			QDEL_NULL(removing)
+
+	wearer.mob_mood.unmodify_hud()
+	// Add the moon health hud element
+	health_hud = new(null, original_hud)
+	original_hud.infodisplay += health_hud
+	original_hud.show_hud(original_hud.hud_version)
+	UnregisterSignal(wearer, COMSIG_MOB_HUD_CREATED)
+	signal_registered -= COMSIG_MOB_HUD_CREATED
+
+/// Removes the HUD element from the wearer
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/on_hud_remove(mob/living/carbon/human/wearer)
+	var/datum/hud/original_hud = wearer.hud_used
+	original_hud.infodisplay -= health_hud
+	QDEL_NULL(health_hud)
+	// Restore the old health elements
+	var/atom/movable/screen/stamina/stamina_hud = new(null, original_hud)
+	var/atom/movable/screen/healths/old_health_hud = new(null, original_hud)
+	var/atom/movable/screen/healthdoll/human/health_doll_hud = new(null, original_hud)
+	original_hud.infodisplay += stamina_hud
+	original_hud.infodisplay += old_health_hud
+	original_hud.infodisplay += health_doll_hud
+	wearer.mob_mood.modify_hud()
+	original_hud.show_hud(original_hud.hud_version)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/can_mob_unequip(mob/user)
+	if(!ishuman(user))
+		return ..()
+	var/mob/living/carbon/human/wearer = user
+	if(wearer.get_organ_loss(ORGAN_SLOT_BRAIN) > 0)
+		wearer.balloon_alert(user, "can't strip, brain damaged!")
+		return FALSE
+	return ..()
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/item_attack_response(mob/living/victim, obj/item/weapon, mob/living/attacker)
+	SIGNAL_HANDLER
+	var/visible_message = pick(visible_message_list)
+	visible_message = replacetext(visible_message, "%USER", victim.get_visible_name())
+	visible_message = replacetext(visible_message, "%ATTACKER", attacker.get_visible_name())
+
+	var/self_message = pick(self_message_list)
+	self_message = replacetext(self_message_list, "%ATTACKER", attacker.get_visible_name())
+
+	var/blind_message = pick(blind_message_list)
+	victim.visible_message(span_danger(visible_message), span_userdanger(self_message), span_danger(blind_message))
+	return SIGNAL_MESSAGE_MODIFIED
+
+/// Once you reach this point you're completely brain dead, so lets play our effects before you eat shit
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/kill_wearer(mob/living/carbon/human/wearer)
+	if(IS_HERETIC(wearer))
+		var/datum/action/cooldown/spell/aoe/moon_ringleader/temp_spell = new(wearer)
+		temp_spell.cast(wearer)
+		qdel(temp_spell)
+	var/obj/item/organ/brain/our_brain = wearer.get_organ_slot(ORGAN_SLOT_BRAIN)
+	REMOVE_TRAIT(our_brain, TRAIT_BRAIN_DAMAGE_NODEATH, REF(src))
+	wearer.death()
+
+/// Blows up your head when you die
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/on_death(mob/wearer)
+	SIGNAL_HANDLER
+	if(!ishuman(wearer))
+		return
+	var/mob/living/carbon/human/human_wearer = wearer
+	var/obj/item/bodypart/head/to_explode = human_wearer.get_bodypart(BODY_ZONE_HEAD)
+	if(!to_explode)
+		return
+	human_wearer.visible_message(span_warning("[human_wearer]'s head splatters with a sickening crunch!"), ignored_mobs = list(human_wearer))
+	new /obj/effect/gibspawner/generic(get_turf(human_wearer), human_wearer)
+	to_explode.dismember(dam_type = BRUTE, silent = TRUE)
+	to_explode.drop_organs()
+	qdel(to_explode)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/process(seconds_per_tick)
+	var/mob/living/carbon/human/wearer = loc
+	if(!istype(wearer) || wearer.wear_suit != src || wearer.stat == DEAD)
+		return ..()
+	if(!IS_HERETIC_OR_MONSTER(wearer))
+		wearer.adjustOrganLoss(ORGAN_SLOT_BRAIN, 20)
+	var/brain_damage = wearer.get_organ_loss(ORGAN_SLOT_BRAIN)
+	var/emote_rng = 0
+	var/list/emote_list = list()
+	switch(brain_damage)
+		if(0)
+			emote_rng = 0
+			emote_list = list()
+		if(1 to 30)
+			emote_rng = 20
+			emote_list = list("laugh")
+		if(31 to 60)
+			emote_rng = 40
+			emote_list = list("laugh", "smile")
+		if(61 to 100)
+			emote_rng = 60
+			emote_list = list("laugh", "smile", "cough")
+		if(101 to 150)
+			emote_rng = 80
+			emote_list = list("laugh", "smile", "cough", "gasp")
+		if(151 to 200)
+			emote_rng = 100
+			emote_list = list("laugh", "smile", "cough", "gasp", "scream")
+	if(!prob(emote_rng))
+		return
+	for(var/perform in emote_list)
+		wearer.emote("[perform]")
+	check_braindeath(wearer)
+
+/// Checks if you are brain dead, starts the dying process once you've reached it
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/proc/check_braindeath(mob/living/carbon/human/wearer)
+	var/obj/item/organ/brain/our_brain = wearer.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(braindead || our_brain.damage < our_brain.maxHealth)
+		return
+
+	braindead = TRUE
+	wearer.setOrganLoss(ORGAN_SLOT_BRAIN, INFINITY)
+	playsound(wearer, 'sound/effects/pope_entry.ogg', 50)
+	to_chat(wearer, span_bold(span_hypnophrase("A terrible fate has befallen you.")))
+	addtimer(CALLBACK(src, PROC_REF(kill_wearer), wearer), 5 SECONDS)
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/moon
+	name = "\improper Resplendant Hood"
+	icon_state = "moon_armor"
+	armor_type = /datum/armor/eldritch_armor/moon
+
+/datum/armor/eldritch_armor/moon
+	melee = 0
+	bullet = 0
+	laser = 0
+	energy = 0
+	bomb = 0
+	bio = 0
+	fire = 0
+	acid = 0
+	wound = 0
+
+/atom/movable/screen/moon_health
+	name = "Health Level"
+	icon = 'icons/hud/moon_health_64x64.dmi'
+	icon_state = "moon_hud_1"
+	base_icon_state = "moon_hud"
+	screen_loc = "EAST-1:0, SOUTH+6:16"
+
+/atom/movable/screen/moon_health/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	if(isnull(hud_owner) || !ishuman(hud_owner.mymob))
+		return INITIALIZE_HINT_QDEL
+	var/mob/living/carbon/human/wearer = hud_owner.mymob
+	var/obj/item/organ/brain/our_brain = wearer.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!our_brain)
+		return INITIALIZE_HINT_QDEL
+	update_health(our_brain)
+	RegisterSignal(our_brain, COMSIG_ORGAN_ADJUST_DAMAGE, PROC_REF(update_health))
+
+/// Changes the icon based on the brain health of the wearer
+/atom/movable/screen/moon_health/proc/update_health(obj/item/organ/brain, damage_amount, maximum, required_organ_flag)
+	SIGNAL_HANDLER
+	if(!brain.owner || !ishuman(brain.owner))
+		qdel(src)
+		return
+	var/mob/living/carbon/human/wearer = brain.owner
+	if(istype(wearer.wear_suit, /obj/item/clothing/suit/hooded/cultrobes/eldritch/moon))
+		var/obj/item/clothing/suit/hooded/cultrobes/eldritch/moon/robes = wearer.wear_suit
+		if(robes.braindead)
+			icon_state = base_icon_state + "_6"
+			return // Don't update the icon once our "dying" process has begun
+	switch(brain.damage)
+		if(0 to 20)
+			icon_state = base_icon_state + "_1"
+		if(21 to 50)
+			icon_state = base_icon_state + "_2"
+		if(51 to 100)
+			icon_state = base_icon_state + "_3"
+		if(101 to 150)
+			icon_state = base_icon_state + "_4"
+		if(151 to 189)
+			icon_state = base_icon_state + "_5"
+		if(190 to INFINITY)
+			icon_state = base_icon_state + "_6"
+
+// Rust
+// Gains more armor while standing on top of rust. Has an animated overlay
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust
+	name = "\improper Salvaged Remains"
+	desc = "Touching the folds of this plain robe seem to fill you with unease. \
+			Even looking fills you with a sense of vertigo. \
+			Some pulse threatening to pull you within."
+	icon_state = "rust_armor"
+	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch/rust
+	armor_type = /datum/armor/eldritch_armor/rust
+	/// Grace period timer before the
+	COOLDOWN_DECLARE(rust_grace_period)
+	/// If our armor is rusted, used to update the sprite
+	var/rusted = FALSE
+	/// Atom used to animate our overlay
+	var/atom/movable/rust_overlay
+	/// The mutable that is actually overlayed on the mob
+	var/mutable_appearance/rust_appearance
+	/// identifier for the overlay
+	var/static/overlay_id = 0
+	/// Overlay for the armor object
+	var/image/object_overlay
+	/// Overlay for the hood object
+	var/image/hood_object_overlay
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/Initialize(mapload)
+	. = ..()
+	overlay_id++
+	if(!object_overlay)
+		object_overlay = image(icon, icon_state = "rust_armor_overlay")
+	if(!hood_object_overlay)
+		hood_object_overlay = image('icons/obj/clothing/head/helmet.dmi', icon_state = "rust_armor_overlay")
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/on_robes_gained(mob/living/user)
+	. = ..()
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
+	rust_overlay = new()
+	rust_overlay.icon = 'icons/mob/clothing/suits/armor.dmi'
+	rust_overlay.render_target = "*rust_overlay_[overlay_id]"
+	rust_overlay.vis_flags |= VIS_INHERIT_DIR | VIS_INHERIT_LAYER | VIS_INHERIT_ID
+	user.vis_contents += rust_overlay // Should be invisible, we just update the sprite as needed
+
+	rust_appearance = new /mutable_appearance()
+	rust_appearance.render_source = "*rust_overlay_[overlay_id]"
+	update_appearance(UPDATE_ICON)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/on_robes_lost(mob/user, obj/item/clothing/suit/hooded/cultrobes/eldritch/robes)
+	. = ..()
+	if(.)
+		return
+	UnregisterSignal(user, list(COMSIG_MOVABLE_MOVED))
+	user.vis_contents -= rust_overlay
+	rusted = FALSE
+	set_armor(/datum/armor/eldritch_armor/rust)
+
+	REMOVE_TRAIT(user, TRAIT_PIERCEIMMUNE, REF(src))
+	cut_overlay(object_overlay)
+	QDEL_NULL(rust_overlay)
+	QDEL_NULL(rust_appearance)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/robes_side_effect(mob/living/user)
+	. = ..()
+	if(!iscarbon(user))
+		return
+	var/mob/living/carbon/victim = user
+	var/list/organ_list = victim.organs
+	if(!length(organ_list))
+		return
+
+	var/iteration = 0
+	var/organs_to_puke = rand(1, 3)
+	for(var/obj/item/organ/to_puke as anything in organ_list)
+		if(iteration > organs_to_puke)
+			break
+		iteration++
+		addtimer(CALLBACK(src, PROC_REF(vomit_your_guts_out), victim), 1 SECONDS * iteration)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/proc/vomit_your_guts_out(mob/living/carbon/victim)
+	if(QDELETED(victim) || !is_equipped(victim))
+		return
+	victim.vomit(MOB_VOMIT_BLOOD | MOB_VOMIT_MESSAGE | MOB_VOMIT_HARM | MOB_VOMIT_FORCE)
+	victim.spew_organ(rand(4, 6))
+
+/*
+ * Signal proc for [COMSIG_MOVABLE_MOVED].
+ *
+ * Checks if our armor values should be increased on the new turf
+ */
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/proc/on_move(mob/source, atom/old_loc, dir, forced, list/old_locs)
+	SIGNAL_HANDLER
+
+	var/turf/mover_turf = get_turf(source)
+	if(HAS_TRAIT(mover_turf, TRAIT_RUSTY))
+		set_armor(/datum/armor/eldritch_armor/rust/on_rust)
+
+		ADD_TRAIT(source, TRAIT_PIERCEIMMUNE, REF(src))
+		COOLDOWN_RESET(src, rust_grace_period)
+		if(rusted) // Already rusted, don't update overlay
+			return
+		rusted = TRUE
+		update_rust()
+	else
+		if(!rusted) // Already unrusted, don't update overlay
+			return
+		// Start the timer for the first time we step off rust
+		if(!COOLDOWN_STARTED(src, rust_grace_period))
+			COOLDOWN_START(src, rust_grace_period, 1 SECONDS)
+			return
+		if(!COOLDOWN_FINISHED(src, rust_grace_period))
+			return
+
+		// *Actually* remove the effects after our grace period expires.
+		// Keep in mind since we call updates `on_move` this means you can technically stand still to keep the benefits.
+		COOLDOWN_RESET(src, rust_grace_period)
+		set_armor(/datum/armor/eldritch_armor/rust)
+		REMOVE_TRAIT(source, TRAIT_PIERCEIMMUNE, REF(src))
+		rusted = FALSE
+		update_rust()
+
+/// Updates the icon of our overlay and applies the animation
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/proc/update_rust()
+	// Animation + Update the overlay sprite on our armor
+	if(!rusted)
+		rust_overlay?.icon_state = null
+		flick("[worn_icon_state]"+"_off", rust_overlay)
+		cut_overlay(object_overlay)
+		hood?.cut_overlay(hood_object_overlay)
+		return
+	rust_overlay?.icon_state = "[worn_icon_state]" + "_overlay"
+	flick("[worn_icon_state]"+"_on", rust_overlay)
+	add_overlay(object_overlay)
+	hood?.add_overlay(hood_object_overlay)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/rust/worn_overlays(mutable_appearance/standing, isinhands)
+	. = ..()
+	// Should basically catch toggling the hood on/off while standing on rust
+	if(rusted)
+		rust_overlay?.icon_state = "[worn_icon_state]" + "_overlay"
+	else
+		rust_overlay?.icon_state = null
+	. += rust_appearance
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/rust
+	name = "\improper Salvaged Remains"
+	desc = "Touching the folds of this plain robe seem to fill you with unease. \
+			Even looking fills you with a sense of vertigo. \
+			Some pulse threatening to pull you within."
+	icon_state = "rust_armor"
+	armor_type = /datum/armor/eldritch_armor/rust
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/rust/equipped(mob/living/user, slot)
+	. = ..()
+	if(!(slot_flags & slot))
+		UnregisterSignal(user, list(COMSIG_MOVABLE_MOVED))
+		return
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
+
+/*
+ * Signal proc for [COMSIG_MOVABLE_MOVED].
+ *
+ * Checks if our armor values should be increased on the new turf
+ */
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/rust/proc/on_move(mob/source, atom/old_loc, dir, forced, list/old_locs)
+	SIGNAL_HANDLER
+
+	var/turf/mover_turf = get_turf(source)
+	if(HAS_TRAIT(mover_turf, TRAIT_RUSTY))
+		set_armor(/datum/armor/eldritch_armor/rust/on_rust)
+	else
+		set_armor(/datum/armor/eldritch_armor/rust)
+
+/datum/armor/eldritch_armor/rust
+	melee = 30
+	bullet = 30
+	laser = 30
+	energy = 30
+	bomb = 50
+	bio = 30
+	fire = 30
+	acid = 30
+	wound = 30
+
+/datum/armor/eldritch_armor/rust/on_rust
+	melee = 60
+	bullet = 60
+	laser = 60
+	energy = 60
+	bomb = 100
+	bio = 60
+	fire = 60
+	acid = 60
+	wound = 60
+
+// Void
+// Gives you a short stealth when you are hit
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/void
+	name = "\improper Hollow Weave"
+	desc = "At first, the empty canvas of this robe seems to shimmer with a faint, cold light. \
+			Yet upon tracking the shape of the folds more carefully, it is better to describe it as the absence of such a thing."
+	icon_state = "void_armor"
+	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch/void
+	armor_type = /datum/armor/eldritch_armor/void
+	/// Cooldown before we can go back into stealth
+	COOLDOWN_DECLARE(stealth_cooldown)
+	/// Timer before our stealth runs out
+	var/stealth_timer
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/void/on_robes_lost(mob/user, obj/item/clothing/suit/hooded/cultrobes/eldritch/robes)
+	. = ..()
+	if(. || !timeleft(stealth_timer))
+		return
+	// Remove from stealth when you lose the robes
+	deltimer(stealth_timer)
+	end_stealth(user)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/void/robes_side_effect(mob/living/user)
+	. = ..()
+	user.adjust_bodytemperature(-INFINITY)
+	ADD_TRAIT(user, TRAIT_HYPOTHERMIC, REF(src))
+	if(!isliving(user))
+		return
+	var/mob/living/victim = user
+	victim.apply_status_effect(/datum/status_effect/frozenstasis/irresistable)
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/void/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type, damage_type)
+	. = ..()
+	if(!COOLDOWN_FINISHED(src, stealth_cooldown))
+		return
+	COOLDOWN_START(src, stealth_cooldown, 20 SECONDS)
+	stealth_timer = addtimer(CALLBACK(src, PROC_REF(end_stealth), owner), 5 SECONDS, TIMER_STOPPABLE)
+	owner.alpha = 0
+	return TRUE
+
+/obj/item/clothing/suit/hooded/cultrobes/eldritch/void/proc/end_stealth(mob/living/carbon/human/owner)
+	animate(owner, time = 1 SECONDS, alpha = initial(owner.alpha))
+
+/obj/item/clothing/head/hooded/cult_hoodie/eldritch/void
+	name = "\improper Hollow Weave"
+	desc = "At first, the empty canvas of this robe seems to shimmer with a faint, cold light. \
+			Yet upon tracking the shape of the folds more carefully, it is better to describe it as the absence of such a thing."
+	icon_state = "void_armor"
+	armor_type = /datum/armor/eldritch_armor/void
+
+/datum/armor/eldritch_armor/void
+	melee = 40
+	bullet = 40
+	laser = 50
+	energy = 50
+	bomb = 40
+	bio = 40
+	fire = 40
+	acid = 40
+	wound = 40
+
+>>>>>>> faadc2ec438 (fix moon robes runtime + make adjustDamageType be handled by moon robes (#93470))
 // Void cloak. Turns invisible with the hood up, lets you hide stuff.
 /obj/item/clothing/head/hooded/cult_hoodie/void
 	name = "void hood"

--- a/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
+++ b/code/modules/antagonists/heretic/status_effects/heretic_passive.dm
@@ -1,0 +1,590 @@
+#define HERETIC_LEVEL_START 1
+#define HERETIC_LEVEL_UPGRADE 2
+#define HERETIC_LEVEL_FINAL 3
+
+/datum/status_effect/heretic_passive
+	id = "heretic_passive"
+	duration = STATUS_EFFECT_PERMANENT
+	status_type = STATUS_EFFECT_REPLACE
+	alert_type = null
+	on_remove_on_mob_delete = TRUE
+	/// Reference to the owning heretic datum
+	var/datum/antagonist/heretic/heretic_datum
+	///What level is our passive currently on
+	var/passive_level = HERETIC_LEVEL_START
+	/// Name of the passive, used by the UI
+	var/name = "Heretic Passive"
+	var/list/passive_descriptions = list(
+		"Grants you a passive ability based on your heretic type. This ability will upgrade as you gain more power.",
+		"Your passive ability has been upgraded, doing something else.",
+		"Your passive ability has been upgraded to its final form, granting you a powerful new ability.",
+	)
+
+/datum/status_effect/heretic_passive/on_apply()
+	. = ..()
+	heretic_datum = GET_HERETIC(owner)
+	RegisterSignal(heretic_datum, COMSIG_HERETIC_PASSIVE_UPGRADE_FIRST, PROC_REF(heretic_level_upgrade))
+	RegisterSignal(heretic_datum, COMSIG_HERETIC_PASSIVE_UPGRADE_FINAL, PROC_REF(heretic_level_final))
+	if(!heretic_datum)
+		return FALSE
+
+	// Just in case of shenanigans, assume the antag datum is correct about our level
+	if(heretic_datum.passive_level == 3)
+		heretic_level_final()
+		return
+	if(heretic_datum.passive_level == 2)
+		heretic_level_upgrade()
+		return
+
+/datum/status_effect/heretic_passive/on_remove()
+	UnregisterSignal(heretic_datum, list(
+		COMSIG_HERETIC_PASSIVE_UPGRADE_FIRST,
+		COMSIG_HERETIC_PASSIVE_UPGRADE_FINAL,
+	))
+	heretic_datum = null
+	return ..()
+
+/// Gives our first upgrade
+/datum/status_effect/heretic_passive/proc/heretic_level_upgrade()
+	SIGNAL_HANDLER
+	SHOULD_CALL_PARENT(TRUE)
+	passive_level = HERETIC_LEVEL_UPGRADE
+	heretic_datum.passive_level = HERETIC_LEVEL_UPGRADE
+	heretic_datum.update_data_for_all_viewers()
+	if(!heretic_datum.unlimited_blades)
+		heretic_datum.disable_blade_breaking()
+
+/// Gives our final upgrade
+/datum/status_effect/heretic_passive/proc/heretic_level_final()
+	SIGNAL_HANDLER
+	SHOULD_CALL_PARENT(TRUE)
+	if(passive_level == HERETIC_LEVEL_START)
+		heretic_level_upgrade()
+	passive_level = HERETIC_LEVEL_FINAL
+	heretic_datum.passive_level = HERETIC_LEVEL_FINAL
+	heretic_datum.update_data_for_all_viewers()
+
+
+//---- Ash Passive
+// Level 1 grants heat and ash storm immunity
+// Level 2 grants lava immunity
+// Level 3 grants resistance to high pressure
+/datum/status_effect/heretic_passive/ash
+	name = "Vow of Destruction"
+	passive_descriptions = list(
+		"Heat and ash storm immunity.",
+		"Lava immunity.",
+		"Resistance to high and low pressure."
+	)
+
+/datum/status_effect/heretic_passive/ash/on_apply()
+	. = ..()
+	owner.add_traits(list(TRAIT_RESISTHEAT, TRAIT_ASHSTORM_IMMUNE), REF(src))
+
+/datum/status_effect/heretic_passive/ash/heretic_level_upgrade()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_LAVA_IMMUNE, REF(src))
+
+/datum/status_effect/heretic_passive/ash/heretic_level_final()
+	. = ..()
+	owner.add_traits(list(TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTLOWPRESSURE), REF(src))
+
+/datum/status_effect/heretic_passive/ash/on_remove()
+	owner.remove_traits(list(TRAIT_RESISTHEAT, TRAIT_ASHSTORM_IMMUNE, TRAIT_LAVA_IMMUNE, TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTLOWPRESSURE), REF(src))
+	return ..()
+
+//---- Blade Passive
+// Gives you riposte while wielding a heretic blade
+// Cooldown starts at 20 and goes down 5 seconds per level
+// Level 1 has a 20 second cooldown + counts as block
+// Level 2 Makes you immune to fall damage/stun from falling
+// Level 3 only has the cooldown reduction (nothing else added)
+/datum/status_effect/heretic_passive/blade
+	name = "Dance of the Brand"
+	id = "blade_passive"
+	passive_descriptions = list(
+		"Being attacked while wielding a Heretic Blade in either hand will deliver a free, instant counterattack to the attacker. This effect can only trigger once every 20 seconds.",
+		"Immunity to fall damage.",
+		"Cooldown of the riposte reduced to 10 seconds."
+	)
+	/// The cooldown before we can riposte again
+	var/base_cooldown = 20 SECONDS
+	/// The cooldown reduction gained from upgrading
+	var/cooldown_reduction = 5 SECONDS
+	/// Whether the counter-attack is ready or not.
+	/// Used so we can give feedback when it's ready again
+	var/riposte_ready = TRUE
+
+/datum/status_effect/heretic_passive/blade/on_apply()
+	. = ..()
+	RegisterSignal(owner, COMSIG_LIVING_CHECK_BLOCK, PROC_REF(on_shield_reaction))
+
+/datum/status_effect/heretic_passive/blade/heretic_level_upgrade()
+	. = ..()
+	RegisterSignal(owner, COMSIG_LIVING_Z_IMPACT, PROC_REF(z_impact_react))
+
+/datum/status_effect/heretic_passive/blade/on_remove()
+	. = ..()
+	UnregisterSignal(owner, list(COMSIG_LIVING_CHECK_BLOCK, COMSIG_LIVING_Z_IMPACT))
+
+/// Blocks the effects from falling
+/datum/status_effect/heretic_passive/blade/proc/z_impact_react(datum/source, levels, turf/fell_on)
+	SIGNAL_HANDLER
+	new /obj/effect/temp_visual/mook_dust(fell_on)
+	owner.visible_message(span_notice("[owner] lands on [fell_on] safely, and quite stylishly on [p_their()] feet!"))
+	INVOKE_ASYNC(owner, TYPE_PROC_REF(/atom, SpinAnimation), 0.5 SECONDS, 0)
+	INVOKE_ASYNC(owner, TYPE_PROC_REF(/mob/, emote), "flip")
+	return ZIMPACT_CANCEL_DAMAGE | ZIMPACT_NO_MESSAGE | ZIMPACT_NO_SPIN
+
+/// Checks if we can counter-attack
+/datum/status_effect/heretic_passive/blade/proc/on_shield_reaction(
+	mob/living/carbon/human/source,
+	atom/movable/hitby,
+	damage = 0,
+	attack_text = "the attack",
+	attack_type = MELEE_ATTACK,
+	armour_penetration = 0,
+	damage_type = BRUTE,
+)
+	SIGNAL_HANDLER
+
+	if(attack_type != MELEE_ATTACK)
+		return
+
+	if(!riposte_ready)
+		return
+
+	if(INCAPACITATED_IGNORING(source, INCAPABLE_GRAB))
+		return
+
+	var/mob/living/attacker = hitby.loc
+	if(!istype(attacker))
+		return
+
+	if(!source.Adjacent(attacker))
+		return
+
+	// Let's check their held items to see if we can do a riposte
+	var/obj/item/main_hand = source.get_active_held_item()
+	var/obj/item/off_hand = source.get_inactive_held_item()
+	// This is the item that ends up doing the "blocking" (flavor)
+	var/obj/item/striking_with
+
+	// First we'll check if the offhand is valid
+	if(!QDELETED(off_hand) && istype(off_hand, /obj/item/melee/sickly_blade))
+		striking_with = off_hand
+
+	// Then we'll check the mainhand
+	// We do mainhand second, because we want to prioritize it over the offhand
+	if(!QDELETED(main_hand) && istype(main_hand, /obj/item/melee/sickly_blade))
+		striking_with = main_hand
+
+	// No valid item in either slot? No riposte
+	if(!striking_with)
+		return
+
+	// If we made it here, deliver the strike
+	INVOKE_ASYNC(src, PROC_REF(counter_attack), source, attacker, striking_with, attack_text)
+
+	// And reset after a bit
+	riposte_ready = FALSE
+	addtimer(CALLBACK(src, PROC_REF(reset_riposte), source), (base_cooldown - cooldown_reduction * (passive_level - 1)))
+
+	if(passive_level > HERETIC_LEVEL_START)
+		return SUCCESSFUL_BLOCK
+
+/// Does the actual counter-attack
+/datum/status_effect/heretic_passive/blade/proc/counter_attack(mob/living/carbon/human/source, mob/living/target, obj/item/melee/sickly_blade/weapon, attack_text)
+	playsound(get_turf(source), 'sound/items/weapons/parry.ogg', 100, TRUE)
+	source.balloon_alert(source, "riposte used")
+	source.visible_message(
+		span_warning("[source] leans into [attack_text] and delivers a sudden riposte back at [target]!"),
+		span_warning("You lean into [attack_text] and deliver a sudden riposte back at [target]!"),
+		span_hear("You hear a clink, followed by a stab."),
+	)
+	weapon.melee_attack_chain(source, target)
+
+/// Gives feedback to the user
+/datum/status_effect/heretic_passive/blade/proc/reset_riposte(mob/living/carbon/human/source)
+	riposte_ready = TRUE
+	source.balloon_alert(source, "riposte ready")
+
+//---- Cosmic Passive
+// Level 1 Cosmic fields will speed up the caster and provide stamina regen
+// Level 2 Cosmic fields will disable any nearby bombs/TTVs/Syndicate Bombs
+// Level 3 Cosmic fields will temporarily slow down bullets that pass through them
+/datum/status_effect/heretic_passive/cosmic
+	name = "Chosen of the Stars"
+	id = "cosmic_passive"
+	passive_descriptions = list(
+		"Cosmic fields speed you up and regenerate stamina.",
+		"Cosmic fields disrupt grenades or signalers from being activated and turn off already primed grenades.",
+		"Cosmic fields slow projectiles down."
+	)
+
+/datum/status_effect/heretic_passive/cosmic/tick(seconds_between_ticks)
+	. = ..()
+	if(locate(/obj/effect/forcefield/cosmic_field) in get_turf(owner))
+		var/delta_time = DELTA_WORLD_TIME(SSmobs) * 0.5 // SSmobs.wait is 2 secs, so this should be halved.
+		owner.adjustStaminaLoss(-15 * delta_time, updating_stamina = FALSE)
+
+/**
+ * Creates a cosmic field at a given loc
+ *
+ * * Args:
+ * * `loc`: Where the cosmic field is created
+ * * Optional `creator`: Checks if the passed mob has a cosmic passive. Upgrades the cosmic field based on their passive level
+ * * Optional `type`: Makes a specific type of cosmic field if we don't want the default
+ */
+/proc/create_cosmic_field(loc, mob/living/creator, type = /obj/effect/forcefield/cosmic_field)
+	var/obj/effect/forcefield/cosmic_field/new_field
+	new_field = new type(loc)
+
+	if(!creator || !ismob(creator))
+		return
+	if(isstargazer(creator))
+		new_field.slows_projectiles()
+		new_field.prevents_explosions()
+		return
+	var/datum/status_effect/heretic_passive/cosmic/cosmic_passive = creator.has_status_effect(/datum/status_effect/heretic_passive/cosmic)
+	if(!cosmic_passive)
+		return
+	if(cosmic_passive.passive_level > HERETIC_LEVEL_START)
+		new_field.prevents_explosions()
+	if(cosmic_passive.passive_level > HERETIC_LEVEL_UPGRADE)
+		new_field.slows_projectiles()
+
+//---- Flesh Passive
+// Makes you never get disgust, virus immune and immune to damage from space ants
+// Level 2, organs and raw meat heals you. You also become a voracious glutton who likes all food. No slowdown from being fat
+// Level 3, being fat gives damage resistance
+/datum/status_effect/heretic_passive/flesh
+	name = "Ravenous Hunger"
+	id = "flesh_passive"
+	passive_descriptions = list(
+		"Immunity to Diseases, Disgust and space ants.",
+		"Eating organs or meat now heals you, gain the voracious and gluttonous trait and being fat doesn't slow you down.",
+		"Gain a flat 25% damage and stamina damage reduction when fat as well as baton resistance."
+	)
+
+/datum/status_effect/heretic_passive/flesh/on_apply()
+	. = ..()
+	owner.add_traits(list(TRAIT_VIRUSIMMUNE, TRAIT_SPACE_ANT_IMMUNITY), REF(src))
+
+/datum/status_effect/heretic_passive/flesh/tick(seconds_between_ticks)
+	. = ..()
+	owner.set_disgust(0)
+
+/datum/status_effect/heretic_passive/flesh/heretic_level_upgrade()
+	. = ..()
+	RegisterSignal(owner, COMSIG_LIVING_EAT_FOOD, PROC_REF(on_eat))
+	owner.add_traits(list(TRAIT_FAT_IGNORE_SLOWDOWN, TRAIT_VORACIOUS, TRAIT_GLUTTON), REF(src))
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/fat_human = owner
+	fat_human.on_fat() // Make sure to update the movespeed modifier in case we gain the trait while already fat
+	var/obj/item/organ/tongue/tongue = fat_human.get_organ_slot(ORGAN_SLOT_TONGUE)
+	tongue.liked_foodtypes = ALL
+	tongue.disliked_foodtypes = NONE
+	tongue.toxic_foodtypes = NONE
+
+/// Any time you take a bite of something, if it's meat or an organ you will heal some damage
+/datum/status_effect/heretic_passive/flesh/proc/on_eat(mob/eater, atom/food)
+	SIGNAL_HANDLER
+	var/obj/item/organ/consumed_organ = food
+	if(istype(consumed_organ) && consumed_organ.foodtype_flags & MEAT)
+		heal_glutton() // Heal the owner if they eat meat
+		return
+	var/obj/item/food/consumed_food = food
+	if(istype(consumed_food) && consumed_food.foodtypes & MEAT)
+		heal_glutton() // Heal the owner if they eat meat
+
+/datum/status_effect/heretic_passive/flesh/proc/heal_glutton()
+	var/healed_amount = owner.heal_overall_damage(2, 2, updating_health = FALSE)
+	healed_amount += owner.adjustOxyLoss(-2, FALSE)
+	healed_amount += owner.adjustToxLoss(-2, FALSE, TRUE)
+	if(!HAS_TRAIT(owner, TRAIT_NOBLOOD))
+		owner.blood_volume += 2.5
+	if(!iscarbon(owner))
+		return
+	var/mob/living/carbon/carbon_eater = owner
+	for(var/obj/item/bodypart/wounded_limb as anything in carbon_eater.bodyparts)
+		for(var/datum/wound/to_cure as anything in wounded_limb.wounds)
+			to_cure.remove_wound()
+			break
+	if(healed_amount > 0)
+		owner.updatehealth()
+		new /obj/effect/temp_visual/heal(get_turf(owner), COLOR_RED)
+
+/datum/status_effect/heretic_passive/flesh/heretic_level_final()
+	. = ..()
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/fat_human = owner
+	RegisterSignals(fat_human, list(SIGNAL_ADDTRAIT(TRAIT_FAT), SIGNAL_REMOVETRAIT(TRAIT_FAT)), PROC_REF(on_fat))
+	on_fat()
+
+/// Gives/Removes damage resistance when we become/lose fatness
+/datum/status_effect/heretic_passive/flesh/proc/on_fat(datum/source)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/heretic = owner
+	if(HAS_TRAIT(heretic, TRAIT_FAT))
+		heretic.physiology.damage_resistance += 25
+		ADD_TRAIT(heretic, TRAIT_BATON_RESISTANCE, REF(src))
+	else
+		heretic.physiology.damage_resistance -= 25
+		REMOVE_TRAIT(heretic, TRAIT_BATON_RESISTANCE, REF(src))
+
+/datum/status_effect/heretic_passive/flesh/on_remove()
+	. = ..()
+	owner.remove_traits(list(TRAIT_VIRUSIMMUNE, TRAIT_SPACE_ANT_IMMUNITY, TRAIT_FAT_IGNORE_SLOWDOWN, TRAIT_VORACIOUS, TRAIT_GLUTTON, TRAIT_BATON_RESISTANCE), REF(src))
+	UnregisterSignal(owner, list(COMSIG_LIVING_EAT_FOOD, SIGNAL_ADDTRAIT(TRAIT_FAT), SIGNAL_REMOVETRAIT(TRAIT_FAT)))
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/heretic = owner
+	if(!HAS_TRAIT(heretic, TRAIT_FAT))
+		return
+	heretic.physiology.damage_resistance -= 25
+	heretic.on_fat()
+
+//---- Lock Passive
+// On gain you can understand and speak every language
+// Level 1 Shock immunity + Side knowledge is cheaper
+// Level 2 Gains X-ray Vision
+// Level 3 your grasp no longer goes on cooldown when opening things
+/datum/status_effect/heretic_passive/lock
+	name = "Open Invitation"
+	id = "lock_passive"
+	passive_descriptions = list(
+		"Shock insulation, all knowledges researched from the shop are cheaper",
+		"X-ray vision, you can see through walls and objects.",
+		"Grasp no longer goes on cooldown when used to open a door or locker."
+	)
+
+/datum/status_effect/heretic_passive/lock/on_apply()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_SHOCKIMMUNE, REF(src))
+	RegisterSignal(heretic_datum, COMSIG_HERETIC_SHOP_SETUP, PROC_REF(on_shop_setup)) // Just in case we are applying this after the shop was set up
+
+/datum/status_effect/heretic_passive/lock/heretic_level_upgrade()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_XRAY_VISION, REF(src))
+	owner.update_sight()
+
+/datum/status_effect/heretic_passive/lock/heretic_level_final()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_LOCK_GRASP_UPGRADED, REF(src))
+
+/datum/status_effect/heretic_passive/lock/on_remove()
+	UnregisterSignal(owner, COMSIG_HERETIC_SHOP_SETUP)
+	owner.remove_traits(list(TRAIT_SHOCKIMMUNE, TRAIT_XRAY_VISION, TRAIT_LOCK_GRASP_UPGRADED), REF(src))
+	owner.update_sight()
+	return ..()
+
+/datum/status_effect/heretic_passive/lock/proc/on_shop_setup(datum/antagonist/heretic/heretic_datum)
+	SIGNAL_HANDLER
+	var/list/shop = heretic_datum.heretic_shops[HERETIC_KNOWLEDGE_SHOP]
+	for(var/knowledge_type in shop)
+		var/list/heretic_info = shop[knowledge_type]
+		if(heretic_info)
+			heretic_info[HKT_COST] = max(1, heretic_info[HKT_COST] - 1) // Reduce cost by 1, minimum of 1
+
+//---- Moon Passive
+// Heals 5 brain damage per level
+// Prevents brain trauma
+// Level 2 grants sleep immunity
+// Level 3, Mind gate + Ringleader's rise will channel the moon amulet effects
+/datum/status_effect/heretic_passive/moon
+	name = "Do You Hear The Voices Too?"
+	id = "moon_passive"
+	passive_descriptions = list(
+		"Can no longer develop brain traumas, passively regenerates brain health, (this bonus is halved in combat).",
+		"Sleep immunity, increases the ratio at which your brain damage regenerates.",
+		"Mind gate and Ringleader's rise will channel the moon amulet effects, further inreases brain regeneration."
+	)
+	/// Built-in moon amulet which channels through your spells
+	var/obj/item/clothing/neck/heretic_focus/moon_amulet/amulet
+	/// When were we last attacked?
+	var/last_attack = 0
+	/// How long the combat tag lasts for
+	var/combat_lockout = 5 SECONDS
+	/// Boolean if you are wearing the moon amulet
+	var/amulet_equipped = FALSE
+
+/datum/status_effect/heretic_passive/moon/on_apply()
+	. = ..()
+	var/obj/item/organ/brain/our_brain = owner.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!our_brain)
+		return
+	ADD_TRAIT(our_brain, TRAIT_BRAIN_TRAUMA_IMMUNITY, REF(src))
+	owner.AddElement(/datum/element/relay_attackers)
+	RegisterSignal(owner, COMSIG_ATOM_WAS_ATTACKED, PROC_REF(on_attacked))
+
+/// Saves world.time when we are attacked by anything
+/datum/status_effect/heretic_passive/moon/proc/on_attacked(mob/victim, atom/attacker)
+	SIGNAL_HANDLER
+	last_attack = world.time
+
+/datum/status_effect/heretic_passive/moon/tick(seconds_between_ticks)
+	. = ..()
+	var/healing_amount = ((world.time > last_attack + combat_lockout) ? -1 * passive_level * seconds_between_ticks : -2 * passive_level * seconds_between_ticks)
+	if(heretic_datum.ascended)
+		healing_amount = -15 * seconds_between_ticks
+	if(!amulet_equipped)
+		healing_amount *= 0.5 // Half healing if you dont have the moon amulet
+	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, healing_amount)
+
+	var/obj/item/organ/brain/our_brain = owner.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!our_brain)
+		return
+	for(var/datum/brain_trauma/trauma as anything in our_brain.traumas)
+		if(istype(trauma, BRAIN_TRAUMA_MILD) || istype(trauma, BRAIN_TRAUMA_SEVERE))
+			our_brain.cure_trauma_type(trauma.type, trauma.resilience)
+
+/datum/status_effect/heretic_passive/moon/heretic_level_upgrade()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_SLEEPIMMUNE, REF(src))
+
+/datum/status_effect/heretic_passive/moon/heretic_level_final()
+	. = ..()
+	amulet = new()
+
+/datum/status_effect/heretic_passive/moon/on_remove()
+	var/obj/item/organ/brain/our_brain = owner.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!our_brain)
+		return ..()
+	REMOVE_TRAIT(our_brain, TRAIT_BRAIN_TRAUMA_IMMUNITY, REF(src))
+	REMOVE_TRAIT(owner, TRAIT_SLEEPIMMUNE, REF(src))
+	UnregisterSignal(owner, COMSIG_ATOM_WAS_ATTACKED)
+	QDEL_NULL(amulet)
+	return ..()
+
+//---- Rust Passive
+// Level 2 and 3 will increase our rust strength
+// Level 1 provides healing and baton resist when standing on rust
+// Level 2 will heal wounds when standing on rust
+// Level 3 will restore lost limbs when standing on rust
+/datum/status_effect/heretic_passive/rust
+	name = "Leeching Walk"
+	id = "rust_passive"
+	passive_descriptions = list(
+		"Standing on Rusted tiles heals and purge chems off your body.",
+		"Standing on Rusted tiles closes up your wounds and heals your organs, you may now rust reinforced floors and walls, healing effect increased.",
+		"Standing on Rusted tiles regenerates your limbs, you may now rust titanium and plastitanium walls, healing effect increased."
+	)
+
+/datum/status_effect/heretic_passive/rust/on_apply()
+	. = ..()
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
+	RegisterSignal(owner, COMSIG_LIVING_LIFE, PROC_REF(on_life))
+
+/datum/status_effect/heretic_passive/rust/on_remove()
+	. = ..()
+	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_LIFE))
+
+/datum/status_effect/heretic_passive/rust/heretic_level_upgrade()
+	. = ..()
+	if(heretic_datum.rust_strength < 2)
+		heretic_datum.increase_rust_strength() // Bring us up to 2
+
+/datum/status_effect/heretic_passive/rust/heretic_level_final()
+	. = ..()
+	if(heretic_datum.rust_strength < 3)
+		heretic_datum.increase_rust_strength() // Bring us up to 3
+
+/*
+ * Signal proc for [COMSIG_MOVABLE_MOVED].
+ *
+ * Checks if we should have baton resistance on the new turf.
+ */
+/datum/status_effect/heretic_passive/rust/proc/on_move(mob/source, atom/old_loc, dir, forced, list/old_locs)
+	SIGNAL_HANDLER
+
+	var/turf/mover_turf = get_turf(source)
+	if(HAS_TRAIT(mover_turf, TRAIT_RUSTY))
+		ADD_TRAIT(source, TRAIT_BATON_RESISTANCE, REF(src))
+	else
+		REMOVE_TRAIT(source, TRAIT_BATON_RESISTANCE, REF(src))
+
+/**
+ * Signal proc for [COMSIG_LIVING_LIFE].
+ *
+ * Gradually heals the heretic ([source]) on rust,
+ * including baton knockdown and stamina damage.
+ */
+/datum/status_effect/heretic_passive/rust/proc/on_life(mob/living/source, seconds_per_tick, times_fired)
+	SIGNAL_HANDLER
+
+	var/turf/our_turf = get_turf(source)
+	if(!HAS_TRAIT(our_turf, TRAIT_RUSTY))
+		return
+
+	// Heals all damage + Stamina
+	var/need_mob_update = FALSE
+	var/delta_time = DELTA_WORLD_TIME(SSmobs) * 0.5 // SSmobs.wait is 2 secs, so this should be halved.
+	var/main_healing = 1 + 1 * passive_level * delta_time
+	var/stam_healing = 5 + 5 * passive_level * delta_time
+	need_mob_update += source.heal_overall_damage(-main_healing, -main_healing, updating_health = FALSE)
+	need_mob_update += source.adjustStaminaLoss(-stam_healing, updating_stamina = FALSE)
+	need_mob_update += source.adjustToxLoss(-main_healing, updating_health = FALSE, forced = TRUE) // Slimes are people too
+	need_mob_update += source.adjustOxyLoss(-main_healing, updating_health = FALSE)
+	if(need_mob_update)
+		source.updatehealth()
+		new /obj/effect/temp_visual/heal(get_turf(owner), COLOR_BROWN)
+	// Reduces duration of stuns/etc
+	var/stun_reduction = 0.5 * passive_level * delta_time
+	source.AdjustAllImmobility(-stun_reduction)
+	// Heals blood loss
+	if(source.blood_volume < BLOOD_VOLUME_NORMAL)
+		source.blood_volume += 2.5 * delta_time
+	for(var/datum/reagent/reagent as anything in source.reagents.reagent_list)
+		source.reagents.remove_reagent(reagent.type, 2 * reagent.purge_multiplier * REM * seconds_per_tick)
+
+	if(!iscarbon(source))
+		return
+	var/mob/living/carbon/carbon_owner = source
+	if(passive_level < HERETIC_LEVEL_UPGRADE)
+		return
+	for(var/obj/item/bodypart/wounded_limb as anything in carbon_owner.bodyparts)
+		for(var/datum/wound/to_cure as anything in wounded_limb.wounds)
+			to_cure.remove_wound()
+	for(var/obj/item/organ/internal as anything in carbon_owner.organs)
+		internal.apply_organ_damage(round(-2 * seconds_per_tick))
+	if(passive_level < HERETIC_LEVEL_FINAL)
+		return
+	if(length(carbon_owner.get_missing_limbs()))
+		carbon_owner.regenerate_limbs()
+
+//---- Void Passive
+// Level 1 Cold and Low pressure resist
+// Level 2 No breathe
+// Level 3 No slip on water/ice
+/datum/status_effect/heretic_passive/void
+	name = "Aristocrat's Way"
+	id = "void_passive"
+	passive_descriptions = list(
+		"Cold and low pressure immunity.",
+		"You no longer need to breathe.",
+		"Water, ice and slippery surfaces no slip you."
+	)
+
+/datum/status_effect/heretic_passive/void/on_apply()
+	. = ..()
+	owner.add_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTLOWPRESSURE), REF(src))
+
+/datum/status_effect/heretic_passive/void/heretic_level_upgrade()
+	. = ..()
+	ADD_TRAIT(owner, TRAIT_NOBREATH, REF(src))
+
+/datum/status_effect/heretic_passive/void/heretic_level_final()
+	. = ..()
+	owner.add_traits(list(TRAIT_NO_SLIP_WATER, TRAIT_NO_SLIP_ICE, TRAIT_NO_SLIP_SLIDE), REF(src))
+
+/datum/status_effect/heretic_passive/void/on_remove()
+	. = ..()
+	owner.remove_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTLOWPRESSURE, TRAIT_NOBREATH, TRAIT_NO_SLIP_WATER, TRAIT_NO_SLIP_ICE, TRAIT_NO_SLIP_SLIDE), REF(src))
+
+#undef HERETIC_LEVEL_START
+#undef HERETIC_LEVEL_UPGRADE
+#undef HERETIC_LEVEL_FINAL


### PR DESCRIPTION
Original PR: 93470
-----

## About The Pull Request
small followup to fix adjustBruteLoss and etc not being handled by moon robes, as i had refactored it heavily to make the code better, this was a thing i missed
## Why It's Good For The Game
moon robes not blocking damage good, probably
## Changelog
:cl:
fix: moon robes now again will protect you from full body damage like low pressure or high pressure or fire
/:cl:
