### PR TITLE
[TG Mirror] Fix runtime with empty tape recorders burning [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -109,8 +109,8 @@
 	update_appearance()
 
 /obj/item/taperecorder/fire_act(exposed_temperature, exposed_volume)
-	mytape.unspool() //Fires unspool the tape, which makes sense if you don't think about it
-	..()
+	mytape?.unspool() //Fires unspool the tape, which makes sense if you don't think about it
+	return ..()
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/item/taperecorder/attack_hand(mob/user, list/modifiers)


### PR DESCRIPTION
Original PR: 93479
-----

## About The Pull Request

`/obj/item/taperecorder/fire_act()` just assumes it has a tape inside when sometimes it doesn't

## Why It's Good For The Game

Fix runtime
