### PR TITLE
[TG Mirror] removes fov cone (oversight?) medieval pirate helmet [MDB IGNORE]

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -647,10 +647,6 @@
 	acid = 50
 	wound = 20
 
-/obj/item/clothing/head/helmet/military/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
-
 /obj/item/clothing/head/helmet/knight/warlord
 	name = "golden barbute helmet"
 	desc = "There is no man behind the helmet, only a terrible thought."


### PR DESCRIPTION
Original PR: 93465
-----
## About The Pull Request

medieval pirate helmets have an fov cone, i think this is an oversight because I think fov cones have been made obsolete as a whole for various reasons, correct me if im wrong if it is not an oversight.
the PR removes the 90' FOV cone

## Why It's Good For The Game

this PR's main focus is simply fixing a potential oversight to do with a niche helmet that still has an FOV cone

## Changelog

:cl: ArchBTW
fix: removes fov cone (oversight) with medieval pirate helmet
/:cl:
