### PR TITLE
[TG Mirror] Increases melting point of plastic flaps [MDB IGNORE]

### DIFF
--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -84,7 +84,7 @@
 
 /obj/structure/plasticflaps/proc/check_melt(turf/source, datum/gas_mixture/air, temperature)
 	SIGNAL_HANDLER
-	if(temperature < FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+	if(temperature < FIRE_MINIMUM_TEMPERATURE_TO_EXIST * 1.5)
 		return
 	if(!COOLDOWN_FINISHED(src, burn_damage_cd))
 		return


### PR DESCRIPTION
Original PR: 93506
-----
## About The Pull Request
Increases the temperature at which plastic flaps begin taking damage from 373k to ~560k

## Why It's Good For The Game

Been messing around with [this pr](https://github.com/tgstation/tgstation/pull/88914) a bit and built some fun grills as engi. 

Unfortunately, because plastic flaps start melting at the same temperature where things start cooking (100c), it's not possible for the chef to retrofit their coldroom into a grilling environment without some additional atmos tools. This is a shame.

Most flexible PVCs start melting around 200c in real life.  This is a bit higher than that, but it's the future and we can assume the plastic will be cooler.
## Changelog
:cl:
balance: Plastic flaps now resist heat better
/:cl:
