### PR TITLE
[TG Mirror] Admin VV dropdown button to grant all access [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -136,6 +136,7 @@
 #define VV_HK_VIEW_PLANES "view_planes"
 #define VV_HK_GIVE_AI "give_ai"
 #define VV_HK_GIVE_AI_SPEECH "give_ai_speech"
+#define VV_HK_GIVE_ACCESS "give_access"
 
 // /mob/living
 #define VV_HK_GIVE_SPEECH_IMPEDIMENT "impede_speech"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1383,6 +1383,7 @@
 	VV_DROPDOWN_OPTION(VV_HK_GIVE_DIRECT_CONTROL, "Give Direct Control")
 	VV_DROPDOWN_OPTION(VV_HK_OFFER_GHOSTS, "Offer Control to Ghosts")
 	VV_DROPDOWN_OPTION(VV_HK_VIEW_PLANES, "View/Edit Planes")
+	VV_DROPDOWN_OPTION(VV_HK_GIVE_ACCESS, "Give Access")
 
 /mob/vv_do_topic(list/href_list)
 	. = ..()
@@ -1456,6 +1457,12 @@
 		if(!check_rights(R_DEBUG))
 			return
 		usr.client.edit_plane_masters(src)
+
+	if(href_list[VV_HK_GIVE_ACCESS])
+		if(!check_rights(NONE))
+			return
+		AddComponent(/datum/component/simple_access, SSid_access.get_region_access_list(list(REGION_ALL_GLOBAL)))
+		to_chat(usr, span_notice("Access granted."))
 /**
  * extra var handling for the logging var
  */


### PR DESCRIPTION
Original PR: 93427
-----

## About The Pull Request
alternative to #93380 
VV dropdown button to instantly grant a mob all access
would like to add a choice list for different groups of access
eventually perhaps could use a proper debug UI like the ID computers
## Why It's Good For The Game
Admin abuse is one of the fundamental sources of fun and enjoyment for players in Space Station 13. While it’s important for admins to maintain a fair and enjoyable environment, controlled abuse—in the form of whimsical chaos or playful intervention—can enhance the game's unpredictable nature. By giving admins more tools at their disposal, such as an easy way to grant "All Access," we’re tapping into the unique brand of humor and surprise that players have come to love. It gives admins more flexibility to create memorable moments, whether it’s through impromptu interventions or simply giving players more reasons to be on edge.

Ultimately, this feature supports the dynamic and unpredictable world that makes SS13 such a unique experience, allowing admins to enhance player enjoyment without compromising game integrity.
## Changelog
:cl:
admin: New admin/debug VV dropdown button to grant any mob all access. 
admin: Reverse by removing the simple_access component, or edit via its access list variable.
/:cl:
