### PR TITLE
[TG Mirror] Restore Library Admin Console controls and tools [MDB IGNORE]

### DIFF
--- a/tgui/packages/tgui/interfaces/LibraryAdmin/BookListing.tsx
+++ b/tgui/packages/tgui/interfaces/LibraryAdmin/BookListing.tsx
@@ -3,7 +3,7 @@ import { Box, NoticeBox, Stack } from 'tgui-core/components';
 import { useBackend } from '../../backend';
 import { Window } from '../../layouts';
 import { PageSelect } from '../LibraryConsole/components/PageSelect';
-import { SearchAndDisplay } from '../LibraryConsole/components/Search';
+import { SearchAndDisplay } from './Search';
 import type { LibraryAdminData } from './types';
 
 export function BookListing(props) {


### PR DESCRIPTION
Original PR: 93450
-----

## About The Pull Request
This fixes the Admin Library Console missing its expected controls (filters, Raw/All toggle, Delete/Restore actions).
Switch import to ./Search, restoring the correct admin UI.
## Why It's Good For The Game
Closes tgstation/tgstation#92923
<img width="800" height="600" alt="500421163-7c2e2416-ecf5-4ff8-900f-8dc04db9c6f8" src="https://github.com/user-attachments/assets/1bcb3ec3-f7f7-47f5-b932-9c25e6fd88a2" />
## Changelog
:cl:
admin: Restored missing controls in the Library Admin Console (filters, Raw/All toggle, Delete/Restore).
/:cl:
