### PR TITLE
[TG Mirror] Fixes a runtime that can occur sometimes if a mob is gibbed [MDB IGNORE]

### DIFF
--- a/code/modules/surgery/organs/organ_movement.dm
+++ b/code/modules/surgery/organs/organ_movement.dm
@@ -229,7 +229,8 @@
 	moveToNullspace()
 	bodypart_owner = null
 
-	on_bodypart_remove(limb)
+	if(!isnull(limb))
+		on_bodypart_remove(limb)
 
 	return TRUE
 


### PR DESCRIPTION
Original PR: 93513
-----
## About The Pull Request

<img width="994" height="460" alt="image" src="https://github.com/user-attachments/assets/ef7e6eb3-8754-4913-87f1-fad62f03523f" />

Tin, saw a fair bit of this in the logs.

Occurs when `forced_removal()` is called, which removes the chest from the bodyparts list and then gibs the mob.

The individual organ removal procs attempt from the gibbing chain to call `on_bodypart_remove()` but there is no bodypart in the mob to refer to, so it runtimes.

Adds a safety check for such cases, if there is no bodypart there we don't need to be doing anything in `on_bodypart_remove()` in the first place (and it has already been called previously by forced_removal(), presumably).

## Why It's Good For The Game

Less runtime spam

## Changelog

Not player-facing