### PR TITLE
[TG Mirror] Secure safe, secure briefcase, and vaults improvements [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_lockable_storage.dm
+++ b/code/__DEFINES/dcs/signals/signals_lockable_storage.dm
@@ -1,0 +1,4 @@
+// /datum/component/lockable_storage signals
+
+///from base of /datum/component/lockable_storage/proc/set_lock_code(new_code): (obj/source, new_code)
+#define COMSIG_LOCKABLE_STORAGE_SET_CODE "lockable_storage_set_code"

--- a/code/datums/components/crafting/structures.dm
+++ b/code/datums/components/crafting/structures.dm
@@ -105,3 +105,46 @@
 		/obj/item/stack/sheet/iron = 30,
 	)
 	category = CAT_STRUCTURE
+
+/datum/crafting_recipe/secure_safe
+	name = "Secure safe"
+	result = /obj/item/wallframe/secure_safe
+	reqs = list(
+		/obj/item/stack/sheet/plasteel = 10,
+		/obj/item/stack/sheet/mineral/titanium = 5,
+		/obj/item/stack/cable_coil = 5,
+		/obj/item/stack/rods = 5,
+		/obj/item/wallframe/button = 1,
+	)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WELDER, TOOL_DRILL)
+	time = 30 SECONDS
+	category = CAT_STRUCTURE
+
+/datum/crafting_recipe/vault
+	name = "Vault"
+	result = /obj/structure/safe/open
+	reqs = list(
+		/obj/item/stack/sheet/mineral/metal_hydrogen = 20,
+		/obj/item/stack/sheet/mineral/plastitanium = 10,
+		/obj/item/stack/cable_coil = 5,
+		/obj/item/stack/rods = 5,
+		/obj/item/wallframe/secure_safe = 1,
+	)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WELDER, TOOL_DRILL)
+	time = 90 SECONDS
+	category = CAT_STRUCTURE
+	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ON_SOLID_GROUND
+
+/datum/crafting_recipe/vault_floor
+	name = "Floor Vault"
+	result = /obj/structure/safe/floor/open
+	reqs = list(
+		/obj/item/stack/sheet/mineral/metal_hydrogen = 20,
+		/obj/item/stack/sheet/mineral/plastitanium = 10,
+		/obj/item/stack/cable_coil = 5,
+		/obj/item/stack/rods = 5,
+	)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WELDER, TOOL_DRILL)
+	time = 90 SECONDS
+	category = CAT_STRUCTURE
+	crafting_flags = CRAFT_CHECK_DENSITY | CRAFT_ON_SOLID_GROUND

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -85,10 +85,17 @@
 	icon_state = "secure"
 	base_icon_state = "secure"
 	inhand_icon_state = "sec-case"
+	var/stored_lock_code
 
 /obj/item/storage/briefcase/secure/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/lockable_storage)
+	AddComponent(/datum/component/lockable_storage, stored_lock_code)
+	RegisterSignal(src, COMSIG_LOCKABLE_STORAGE_SET_CODE, PROC_REF(update_lock_code))
+
+/obj/item/storage/briefcase/secure/proc/update_lock_code(obj/item/storage/briefcase/secure/briefacase, new_code)
+	SIGNAL_HANDLER
+
+	stored_lock_code = new_code
 
 /// Base container used for gimmick disks.
 /obj/item/storage/briefcase/secure/digital_storage

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -18,7 +18,14 @@ FLOOR SAFES
 	anchored = TRUE
 	density = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	obj_flags = CONDUCTS_ELECTRICITY
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT
+	custom_materials = list(
+		/datum/material/metalhydrogen = SHEET_MATERIAL_AMOUNT*10,
+		/datum/material/alloy/plastitanium = SHEET_MATERIAL_AMOUNT*5,
+	)
+	material_flags = MATERIAL_EFFECTS
+
 	/// The maximum combined w_class of stuff in the safe
 	var/maxspace = 24
 	/// The amount of tumblers that will be generated
@@ -41,13 +48,25 @@ FLOOR SAFES
 /obj/structure/safe/Initialize(mapload)
 	. = ..()
 
-	update_appearance(UPDATE_ICON)
+	var/static/list/tool_behaviors = list(
+		TOOL_WRENCH = list(
+			SCREENTIP_CONTEXT_LMB = "Reset lock",
+		),
+	)
+	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+
 	// Combination generation
 	for(var/iterating in 1 to number_of_tumblers)
 		tumblers.Add(rand(0, 99))
 
-	if(!mapload)
+	if(density)
+		AddElement(/datum/element/climbable)
+		AddElement(/datum/element/elevation, pixel_shift = 22)
+
+	if(open && !locked)
 		return
+
+	update_appearance(UPDATE_ICON)
 
 	// Put as many items on our turf inside as possible
 	for(var/obj/item/inserting_item in loc)
@@ -57,10 +76,45 @@ FLOOR SAFES
 			space += inserting_item.w_class
 			inserting_item.forceMove(src)
 
+/obj/structure/safe/examine(mob/user)
+	. = ..()
+	. += span_notice("The locking mechanism gears are <b>wrenched</b> in place.")
+
 /obj/structure/safe/update_icon_state()
 	//uses the same icon as the captain's spare safe (therefore lockable storage) so keep it in line with that
 	icon_state = "[initial(icon_state)][open ? null : "_locked"]"
 	return ..()
+
+/obj/structure/safe/wrench_act(mob/living/user, obj/item/tool)
+	if(!open)
+		balloon_alert(user, "must be open!")
+		return ITEM_INTERACT_BLOCKING
+
+	balloon_alert(user, "resetting lock...")
+	to_chat(user, span_notice("You begin resetting the lock for [src]. You'll need to set [number_of_tumblers] numbers."))
+
+	var/list/new_tumblers = list()
+	for(var/tumbler_index in 1 to number_of_tumblers)
+		var/input_value = tgui_input_number(user, "Set tumbler #[tumbler_index] (0-99):", "Set Lock", 0, 99, 0)
+		if(isnull(input_value))
+			balloon_alert(user, "reset cancelled!")
+			return ITEM_INTERACT_BLOCKING
+		if(!user.can_perform_action(src))
+			balloon_alert(user, "reset interrupted!")
+			return ITEM_INTERACT_BLOCKING
+		new_tumblers.Add(input_value)
+
+	tool.play_tool_sound(src)
+	if(!do_after(user, 10 SECONDS, target = src))
+		return ITEM_INTERACT_BLOCKING
+
+	tumblers = new_tumblers
+	current_tumbler_index = 1
+	dial = 0
+	tool.play_tool_sound(src)
+	to_chat(user, span_notice("You successfully reset the lock for [src]. The new combination is: [tumblers.Join("-")]."))
+	balloon_alert(user, "lock set!")
+	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/safe/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	if(open)
@@ -238,6 +292,10 @@ FLOOR SAFES
 	if(total_ticks == 1 || prob(SOUND_CHANCE))
 		balloon_alert(user, pick(sounds))
 
+/obj/structure/safe/open
+	open = TRUE
+	locked = FALSE
+
 //FLOOR SAFES
 /obj/structure/safe/floor
 	name = "floor safe"
@@ -248,6 +306,10 @@ FLOOR SAFES
 /obj/structure/safe/floor/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/undertile)
+
+/obj/structure/safe/floor/open
+	open = TRUE
+	locked = FALSE
 
 ///Special safe for the station's vault. Not explicitly required, but the piggy bank inside it is.
 /obj/structure/safe/vault

--- a/code/game/objects/structures/secure_safe.dm
+++ b/code/game/objects/structures/secure_safe.dm
@@ -6,6 +6,16 @@
 	base_icon_state = "wall_safe"
 	result_path = /obj/structure/secure_safe
 	pixel_shift = 32
+	w_class = WEIGHT_CLASS_GIGANTIC
+	obj_flags = CONDUCTS_ELECTRICITY
+	resistance_flags = FIRE_PROOF
+	custom_materials = list(
+		/datum/material/alloy/plasteel = SHEET_MATERIAL_AMOUNT*5,
+		/datum/material/titanium = SHEET_MATERIAL_AMOUNT*3,
+	)
+	material_flags = MATERIAL_EFFECTS
+	/// The lock code transferred from the structure
+	var/stored_lock_code
 
 /obj/item/wallframe/secure_safe/Initialize(mapload)
 	. = ..()
@@ -13,12 +23,55 @@
 		max_specific_storage = WEIGHT_CLASS_GIGANTIC,
 		max_total_storage = 20,
 	)
-	atom_storage.set_locked(STORAGE_FULLY_LOCKED)
+	if(stored_lock_code && !(obj_flags & EMAGGED))
+		atom_storage.set_locked(STORAGE_FULLY_LOCKED)
+	update_appearance()
 
-/obj/item/wallframe/secure_safe/after_attach(obj/attached_to)
+/obj/item/wallframe/secure_safe/update_icon_state()
 	. = ..()
+	if(obj_flags & EMAGGED)
+		icon_state = "[base_icon_state]_broken"
+	else
+		icon_state = "[base_icon_state][stored_lock_code ? "_locked" : null]"
+
+/obj/item/wallframe/secure_safe/emag_act(mob/user, obj/item/card/emag/emag_card)
+	. = ..()
+	if(obj_flags & EMAGGED)
+		return FALSE
+
+	obj_flags |= EMAGGED
+	visible_message(span_warning("Sparks fly from [src]!"), blind_message = span_hear("You hear a faint electrical spark."))
+	balloon_alert(user, "lock destroyed")
+	playsound(src, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	stored_lock_code = null
+	atom_storage.locked = STORAGE_NOT_LOCKED
+	update_appearance()
+	return TRUE
+
+/obj/item/wallframe/secure_safe/after_attach(obj/structure/secure_safe/safe)
+	if(!istype(safe))
+		return ..()
+
 	for(var/obj/item in contents)
-		item.forceMove(attached_to)
+		item.forceMove(safe)
+
+	var/datum/component/lockable_storage/storage_component = safe.GetComponent(/datum/component/lockable_storage)
+	if(stored_lock_code)
+		storage_component?.set_lock_code(stored_lock_code)
+
+	if(obj_flags & EMAGGED)
+		storage_component?.break_lock()
+
+	return ..()
+
+/datum/armor/secure_safe
+	melee = 30
+	bullet = 30
+	laser = 20
+	energy = 20
+	bomb = 30
+	fire = 95
+	acid = 30
 
 /**
  * Wall safes
@@ -33,27 +86,63 @@
 	base_icon_state = "wall_safe"
 	anchored = TRUE
 	density = FALSE
+	resistance_flags = FIRE_PROOF
+	obj_flags = CONDUCTS_ELECTRICITY
+	armor_type = /datum/armor/secure_safe
+	max_integrity = 300
+	damage_deflection = 21
+	custom_materials = list(
+		/datum/material/alloy/plasteel = SHEET_MATERIAL_AMOUNT*5,
+		/datum/material/titanium = SHEET_MATERIAL_AMOUNT*3,
+	)
+	material_flags = MATERIAL_EFFECTS
+	/// The lock code used to open the safe
+	var/stored_lock_code
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/secure_safe, 32)
 
 /obj/structure/secure_safe/Initialize(mapload)
 	. = ..()
 	//this will create the storage for us.
-	AddComponent(/datum/component/lockable_storage)
+	AddComponent(/datum/component/lockable_storage, stored_lock_code)
+
 	if(!density)
 		find_and_hang_on_wall()
 	if(mapload)
 		PopulateContents()
 
+	RegisterSignal(src, COMSIG_LOCKABLE_STORAGE_SET_CODE, PROC_REF(update_lock_code))
+
 /obj/structure/secure_safe/atom_deconstruct(disassembled)
 	if(!density) //if we're a wall item, we'll drop a wall frame.
 		var/obj/item/wallframe/secure_safe/new_safe = new(get_turf(src))
+
+		// Transfer lock code to the wallframe
+		var/datum/component/lockable_storage/storage_component = GetComponent(/datum/component/lockable_storage)
+		if(storage_component)
+			new_safe.stored_lock_code = storage_component.lock_code
+
+		if(obj_flags & EMAGGED)
+			new_safe.obj_flags |= EMAGGED
+
+		new_safe.update_appearance()
+
 		for(var/obj/item in contents)
 			item.forceMove(new_safe)
 
 /obj/structure/secure_safe/proc/PopulateContents()
 	new /obj/item/paper(src)
 	new /obj/item/pen(src)
+
+/obj/structure/secure_safe/proc/update_lock_code(obj/structure/secure_safe/safe, new_code)
+	SIGNAL_HANDLER
+
+	stored_lock_code = new_code
+
+/obj/structure/secure_safe/ex_act(severity, target)
+	if(severity <= EXPLODE_LIGHT)
+		return FALSE
+	return ..()
 
 /obj/structure/secure_safe/hos
 	name = "head of security's safe"
@@ -77,11 +166,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/secure_safe, 32)
 	icon_state = "spare_safe"
 	base_icon_state = "spare_safe"
 	armor_type = /datum/armor/safe_caps_spare
-	max_integrity = 300
 	damage_deflection = 30 // prevents stealing the captain's spare using null rods/lavaland monsters/AP projectiles
 	density = TRUE
 	anchored_tabletop_offset = 6
-	custom_materials = list(/datum/material/gold = SMALL_MATERIAL_AMOUNT)
+	custom_materials = list(
+		/datum/material/alloy/plasteel = SHEET_MATERIAL_AMOUNT*5,
+		/datum/material/gold = SHEET_MATERIAL_AMOUNT*3,
+	)
 	material_flags = MATERIAL_EFFECTS
 
 /datum/armor/safe_caps_spare

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -344,6 +344,7 @@
 #include "code\__DEFINES\dcs\signals\signals_leash.dm"
 #include "code\__DEFINES\dcs\signals\signals_lift.dm"
 #include "code\__DEFINES\dcs\signals\signals_light_eater.dm"
+#include "code\__DEFINES\dcs\signals\signals_lockable_storage.dm"
 #include "code\__DEFINES\dcs\signals\signals_market.dm"
 #include "code\__DEFINES\dcs\signals\signals_material_container.dm"
 #include "code\__DEFINES\dcs\signals\signals_medical.dm"


### PR DESCRIPTION
Original PR: 93085
-----
## About The Pull Request

This buffs secure safes quite a bit:
- Armor deflection and resistance is the same as airlocks
- Slightly blast resistant and can ignore light explosions
- Fire-proof and conducts electricity
- Max integrity for all secure safes is 300

Fixes:
- Secure safe state not transferring to the obj when it gets deconstructed from a wall

Adds a `to_chat` notification of the new PIN code for secure safes and briefcases in case you forget. Admins are also able to track the PIN code under a the `var/stored_lock_code`.

It also makes vaults climbable since they are nearly indestructible (only destroyed by multiple explosions) and I want to avoid a situation where players might try to wall in the nuke disk or nuke, with a 3x3 tile of vaults. 

This also adds 3 new crafting recipes.

### Secure Safe
- Titanium x10
- Plasteel x5
- Cable Coil x5
- Iron Rod x5
- Button x1

**Crafting time:** 30 seconds
**Required tools:** Screwdriver, Welder, Drill

---

### Vault
- Metal Hydrogen x20
- Plastitanium x10
- Cable Coil x5
- Iron Rod x5
- Secure Safe x1

**Crafting time:** 90 seconds
**Required tools:** Screwdriver, Welder, Drill

---

### Floor Vault
_(same crafting recipe as the Vault)_

## Why It's Good For The Game
This change adds new crafting options for objects that were previously uncreatable. The recipes use rarer materials, giving players more reasons to seek them out and providing a purpose for materials that were underutilized in existing crafting recipes.

## Changelog
:cl:
add: Secure safes are now fire-proof, conduct electricity, are resistant to light explosions, and have armor/health that is similar to airlocks.
add: A message will now appear in your chat log when you set the PIN code for a secure briefcase or secure safe in case people forget.
add: Vaults are now climbable, except floor ones.
add: Add crafting recipes for secure safe and vaults. When vaults are crafted, they spawn open and can have their locking mechanism set via a wrench.
fix: Secure safes will now transfer their state (locked, PIN code, emagged, etc.) when deconstructed from a wall and vice-versa.
/:cl:
