### PR TITLE
[TG Mirror] Cursed players have an increased chance of drawing bad tarot cards [MDB IGNORE]

### DIFF
--- a/code/modules/cards/cards.dm
+++ b/code/modules/cards/cards.dm
@@ -131,12 +131,17 @@
 
 	var/list/cards = fetch_card_atoms()
 
-	card = card || cards[1] //draw the card on top
+	card ||= pick_card(user, cards)
 	cards -= card
 
 	update_appearance()
 	playsound(src, 'sound/items/cards/cardflip.ogg', 50, TRUE)
 	return card
+
+/// Picks what card the user draws from the deck
+/obj/item/toy/cards/proc/pick_card(mob/living/user, list/obj/item/toy/singlecard/cards)
+	// By default just pick the top card
+	return cards[1]
 
 /// Returns the cards in this deck.
 /// Lazily generates the cards if they haven't already been made.

--- a/code/modules/cards/deck/tarot.dm
+++ b/code/modules/cards/deck/tarot.dm
@@ -28,6 +28,23 @@
 		M.Turn(180)
 		card.transform = M
 
+/obj/item/toy/cards/deck/tarot/pick_card(mob/living/user, list/obj/item/toy/singlecard/cards)
+	// If the user is cursed they have increase chance of drawing Death or The Tower
+	if(!HAS_TRAIT(user, TRAIT_CURSED))
+		return ..()
+
+	var/total_card = length(cards)
+	// give a boosted chance if they're using the full deck
+	var/chance_modifier = total_card >= 56 ? 24 : 4
+	if(!prob(min(33, chance_modifier / total_card * 100)))
+		return ..()
+
+	for(var/obj/item/toy/singlecard/card as anything in cards)
+		if(card.cardname == "Death" || card.cardname == "The Tower")
+			return card
+
+	return ..()
+
 /obj/item/toy/cards/deck/tarot/haunted
 	name = "haunted tarot game deck"
 	desc = "A spooky looking tarot deck. You can sense a supernatural presence linked to the cards..."


### PR DESCRIPTION
Original PR: 93511
-----
## About The Pull Request

Having `TRAIT_CURSED` drastically increases your chance of drawing "Death" or "The Tower" from a tarot deck

## Why It's Good For The Game

Well it's called "bad luck" for a reason

## Changelog


:cl: Melbert
add: Cursed / Unlucky players have an increased chance of drawing bad tarot cards
/:cl:
