### PR TITLE
[TG Mirror] [NO GBP] Fixes borg flashing [MDB IGNORE]

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -264,19 +264,12 @@
 	// Attacker lateral to the victim.
 	return DEVIATION_PARTIAL
 
-/obj/item/assembly/flash/attack(mob/living/M, mob/user)
+/obj/item/assembly/flash/attack(mob/living/target, mob/user)
 	if(!try_use_flash(user))
 		return FALSE
 
-	. = TRUE
-	if(!issilicon(M))
-		flash_mob(M, user, confusion_duration = 5 SECONDS, targeted = TRUE)
-		return
-	flash_silicon(M, user)
-
-	user.visible_message(span_warning("[user] fails to blind [M] with the flash!"), span_warning("You fail to blind [M] with the flash!"))
-
-/obj/item/assembly/flash/proc/flash_silicon(mob/living/silicon/silicon)
+	flash_mob(target, user, confusion_duration = 5 SECONDS, targeted = TRUE)
+	return TRUE
 
 /obj/item/assembly/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
 	if(holder)


### PR DESCRIPTION
Original PR: 93527
-----
## About The Pull Request
Flashing a borg still called a dead proc I forgot to remove from the code. Now it's fixed.

## Why It's Good For The Game
Fixes an issue that hasn't been reported yet. I don't have the time to implement any unit test rn tho.

## Changelog

:cl:
fix: Fixes borg being chiefly unaffected by flashes.
/:cl:
