### PR TITLE
[TG Mirror] Fix infinite capacity power cell/battery use() method return values [MDB IGNORE]

### DIFF
--- a/code/modules/power/battery.dm
+++ b/code/modules/power/battery.dm
@@ -77,3 +77,17 @@
 
 /obj/item/stock_parts/power_store/battery/crap/empty
 	empty = TRUE
+<<<<<<< HEAD
+=======
+
+/obj/item/stock_parts/power_store/battery/infinite
+	name = "infinite-capacity megacell"
+	desc = "A transdimensional megacell with an inexhaustible capacity."
+	icon_state = "icellbig"
+	maxcharge = INFINITY
+	chargerate = INFINITY
+	ratingdesc = FALSE
+
+/obj/item/stock_parts/power_store/battery/infinite/use(used, force = FALSE)
+	return used
+>>>>>>> 3836e13c7d2 (Fix infinite capacity power cell/battery use() method return values (#93544))

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -161,7 +161,7 @@
 	ratingdesc = FALSE
 
 /obj/item/stock_parts/power_store/cell/infinite/use(used, force = FALSE)
-	return TRUE
+	return used
 
 /obj/item/stock_parts/power_store/cell/infinite/abductor
 	name = "void core"


### PR DESCRIPTION
Original PR: 93544
-----

## About The Pull Request
Infinite capacity power cells and megacells were returning TRUE (which evaluates to 1) instead of the actual amount used in their use() methods. This caused bugs when large electrical loads were applied, as the power system expected the actual amount consumed to be returned for proper power accounting. Without this fix, the infinite capacity megacell would not work properly on the main power grid of the station as the load would be too big, and it would choke the power grid. 

This is the use() method.
```C
/// Use power from the cell.
/// Args:
/// - used: Amount of power in joules to use.
/// - force: If true, uses the remaining power from the cell if there isn't enough power to supply the demand.
/// Returns: The power used from the cell in joules.
/obj/item/stock_parts/power_store/use(used, force = FALSE)
    var/power_used = min(used, charge)     // Calculate how much power we can actually provide
    if(rigged && power_used > 0)
        explode()
        return 0                           // Cell exploded, no power provided
    if(!force && charge < used)
        return 0                           // Not enough charge and force=FALSE, no power provided
    charge -= power_used                   // Reduce the cell's charge by the amount used
    if(!istype(loc, /obj/machinery/power/apc))
        SSblackbox.record_feedback("tally", "cell_used", 1, type)
    return power_used                      // Return the actual amount of power provided
```

It is overridden in battery.dm and cell.dm but the override is implemented inccorectly. This PR fixes that.

Changes:
- battery.dm: Changed infinite battery use() to return used instead of TRUE
- cell.dm: Changed infinite cell use() to return used instead of TRUE
## Why It's Good For The Game
Its a bug fix.
## Changelog
:cl:

fix: Fixed a bug where infinite capacity power cells and megacells wouldn't work on large power grids (high loads).

/:cl:
