### PR TITLE
[TG Mirror] The Inversenning : Chiral Inversing Buffer  [MDB IGNORE]

### DIFF
--- a/code/datums/mapgen/Cavegens/IcemoonCaves.dm
+++ b/code/datums/mapgen/Cavegens/IcemoonCaves.dm
@@ -26,11 +26,12 @@
 
 	///Note that this spawn list is also in the lavaland generator
 	weighted_feature_spawn_list = list(
-		/obj/structure/geyser/hollowwater = 10,
-		/obj/structure/geyser/plasma_oxide = 10,
-		/obj/structure/geyser/protozine = 10,
+		/obj/structure/geyser/hollowwater = 8,
+		/obj/structure/geyser/plasma_oxide = 8,
+		/obj/structure/geyser/protozine = 8,
 		/obj/structure/geyser/random = 2,
-		/obj/structure/geyser/wittel = 10,
+		/obj/structure/geyser/wittel = 8,
+		/obj/structure/geyser/chiral_buffer = 8,
 		/obj/structure/ore_vent/boss/icebox = 1,
 	)
 
@@ -45,11 +46,12 @@
 
 	feature_spawn_chance = 0.15
 	weighted_feature_spawn_list = list(
-		/obj/structure/geyser/hollowwater = 10,
-		/obj/structure/geyser/plasma_oxide = 10,
-		/obj/structure/geyser/protozine = 10,
+		/obj/structure/geyser/hollowwater = 8,
+		/obj/structure/geyser/plasma_oxide = 8,
+		/obj/structure/geyser/protozine = 8,
 		/obj/structure/geyser/random = 2,
-		/obj/structure/geyser/wittel = 10,
+		/obj/structure/geyser/wittel = 8,
+		/obj/structure/geyser/chiral_buffer = 8,
 	)
 
 	weighted_flora_spawn_list = list(

--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -29,11 +29,12 @@
 
 	///Note that this spawn list is also in the icemoon generator
 	weighted_feature_spawn_list = list(
-		/obj/structure/geyser/hollowwater = 10,
-		/obj/structure/geyser/plasma_oxide = 10,
-		/obj/structure/geyser/protozine = 10,
+		/obj/structure/geyser/hollowwater = 8,
+		/obj/structure/geyser/plasma_oxide = 8,
+		/obj/structure/geyser/protozine = 8,
 		/obj/structure/geyser/random = 2,
-		/obj/structure/geyser/wittel = 10,
+		/obj/structure/geyser/wittel = 8,
+		/obj/structure/geyser/chiral_buffer = 8,
 		/obj/structure/ore_vent/boss = 1,
 	)
 

--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -108,6 +108,12 @@
 	reagent_id = /datum/reagent/water/hollowwater
 	true_name = "hollow water geyser"
 
+/obj/structure/geyser/chiral_buffer
+	reagent_id = /datum/reagent/reaction_agent/inversing_buffer
+	point_value = 250
+	true_name = "chiral inversing geyser"
+	discovery_message = "It's a rare chiral inversing geyser! This could be very powerful in the right hands... "
+
 /obj/structure/geyser/random
 	point_value = 500
 

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -226,3 +226,11 @@
 		/obj/item/pestle,
 	)
 	crate_name = "organ growing kit"
+
+/datum/supply_pack/medical/chiral_inversing_buffer
+	name = "Chiral Inversing Buffer Crate"
+	desc = "A crate containing a rare sample of an inversing buffer. \
+		It can transform impure reagents into their inverse counterparts when the right conditions are met."
+	cost = CARGO_CRATE_VALUE * 3
+	contains = list(/obj/item/reagent_containers/cup/bottle/inversing_buffer)
+	crate_name = "chiral inversing buffer crate"

--- a/code/modules/reagents/chemistry/reagents/reaction_agents_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/reaction_agents_reagents.dm
@@ -144,3 +144,31 @@
 		holder.update_total()
 
 #undef SPEED_REAGENT_STRENGTH
+
+/datum/reagent/reaction_agent/inversing_buffer
+	name = "Chiral Inversing Buffer"
+	description = "This reagent will consume itself and convert impure reagents into their inversed counterparts. Amount varies based on volume of added buffer."
+	ph = 7
+	color = "#b60046"
+
+/datum/reagent/reaction_agent/inversing_buffer/intercept_reagents_transfer(datum/reagents/target, amount, copy_only)
+	. = ..()
+	if(!.)
+		return
+
+	for(var/_reagent in target.reagent_list)
+		var/datum/reagent/reaction_agent/reagent = _reagent
+		if(reagent.purity <= reagent.inverse_chem_val)
+			target.my_atom.audible_message(span_warning("The beaker goes into a rolling boil as the contents begin inversing!"))
+			playsound(target.my_atom, 'sound/effects/chemistry/catalyst.ogg', 50, TRUE)
+			var/converted = min(reagent.volume, amount * 10)//Converts up to 10 units of reagent per 1 unit of inversing buffer.
+			if(converted > 0)
+				target.remove_reagent(reagent.type, converted, safety = FALSE)
+				target.add_reagent(reagent.inverse_chem, converted, FALSE, added_purity = reagent.get_inverse_purity(reagent.purity))
+				volume -= amount
+				holder.update_total()
+				break
+		else
+			target.my_atom.audible_message(span_warning("The buffer quietly fizzles away with no effect."))
+			volume -= amount
+			holder.update_total()

--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -261,6 +261,11 @@
 	desc = "A small bottle of basic buffer."
 	list_reagents = list(/datum/reagent/reaction_agent/basic_buffer = 30)
 
+/obj/item/reagent_containers/cup/bottle/inversing_buffer
+	name = "Chiral inversing buffer bottle"
+	desc = "A small bottle of chiral inversing buffer."
+	list_reagents = list(/datum/reagent/reaction_agent/inversing_buffer = 30)
+
 /obj/item/reagent_containers/cup/bottle/romerol
 	name = "romerol bottle"
 	desc = "A small bottle of Romerol. The REAL zombie powder."


### PR DESCRIPTION
Original PR: 93376
-----
## About The Pull Request

This PR adds a new buffer (and accompanying Lavaland geyser) to the game: Chiral Inversing Buffer! This unique buffer allows you to instantly transmute a hidden impure or inverse reagent into its original form, no hassle with the HPLC. It can be acquired in three ways, two of which involve Cargo. You can purchase a crate containing one 30u bottle of the buffer for 600 credits, or for free through Medbay's cargo console. You can also scour Lavaland and uncover a geyser that offers unlimited buffer.

The buffer itself checks if any eligible inverses or impurities are present within the holder. If there is none, the buffer will fizzle out and be effectively wasted. If there is an eligible reagent, it converts the reagent into the Inverse at a 10-to-1 ratio with the buffer. This means that buying a bottle from cargo will net you at max, 300 units of instant inversing. Do note that this buffer has the best results when added after a reaction, not during or before.


https://github.com/user-attachments/assets/5f04097d-6baa-4cfd-bf0d-77f175d37acb



## Why It's Good For The Game

This was made from the suggestions of my previous PR at #93316. The main issue that this PR targets is the lack of speedy access to "true" inverse reagents. The current system hides the name of most inverses on creation and only has the HPLC to reliably convert hidden inverses into their true counterpart. This can cause issues with some inverses due to them still retaining some properties of their base reagent. While that system cannot be removed as of now, this PR serves to add another alternative for Chemists to pursue if they need to purify their inverse outputs.

<img width="135" height="136" alt="chiralgeyser" src="https://github.com/user-attachments/assets/1cb336ac-966e-4c4b-8cb2-68616c410f26" />


## Changelog
:cl:
add: Chiral Inversing Buffer : A new way to convert your hidden impurities and inverses into their true form! Requires a purchase from Cargo or a trip to Lavaland to acquire.
balance: A new geyser has been added to Lavaland that outputs Chiral Inversing Buffer. Geyser weights have been adjusted to accommodate this addition.
/:cl:
