### PR TITLE
[TG Mirror] [NO GBP] Fixes temporary deafness [MDB IGNORE]

### DIFF
--- a/code/modules/surgery/organs/internal/ears/_ears.dm
+++ b/code/modules/surgery/organs/internal/ears/_ears.dm
@@ -73,6 +73,7 @@
 	// Always show if we have an appendix
 	return ..() || (owner.stat != DEAD && HAS_TRAIT(owner, TRAIT_DEAF))
 
+<<<<<<< HEAD
 /**
  * Snowflake proc to handle temporary deafness
  *
@@ -91,6 +92,15 @@
 	if(mod_deaf)
 		deaf = max(deaf + mod_deaf, 0)
 	update_temp_deafness()
+=======
+///Adjust the temporary deafness of the person, up or down
+/obj/item/organ/ears/proc/adjust_temporary_deafness(amount)
+	// organ failure makes us permanently deafened. Also, doesn't do anything if not in someone or during godmode
+	if(amount > 0 && owner && HAS_TRAIT(owner, TRAIT_GODMODE))
+		return
+
+	temporary_deafness = max(temporary_deafness + amount * damage_multiplier, 0)
+>>>>>>> 07d1ea37714 ([NO GBP] Fixes temporary deafness (#93580))
 
 /// Updates status of deafness
 /obj/item/organ/ears/proc/update_temp_deafness()


### PR DESCRIPTION
Original PR: 93580
-----
## About The Pull Request
Yeah, if we just use the `+=` operator, the temporary deafness will never decrease since the addendum will never be below zero. This PR fixes that.

## Why It's Good For The Game
This will fix #93579 

## Changelog

:cl:
fix: Fixed temporary deafness never going away.
/:cl:
