### PR TITLE
[TG Mirror] fixes a kebab on nebulastation being a basetype [MDB IGNORE]

### DIFF
--- a/_maps/map_files/NebulaStation/NebulaStation.dmm
+++ b/_maps/map_files/NebulaStation/NebulaStation.dmm
@@ -92395,7 +92395,7 @@
 /area/space/nearstation)
 "nMh" = (
 /obj/structure/bonfire/prelit,
-/obj/item/food/kebab,
+/obj/item/food/kebab/monkey,
 /turf/open/misc/asteroid/airless,
 /area/space/nearstation)
 "nMm" = (


### PR DESCRIPTION
Original PR: 93569
-----

## About The Pull Request
There's a basetype kebab outside of chemistry on a bonfire
<img width="413" height="135" alt="ITISNOTFOOD" src="https://github.com/user-attachments/assets/55e2d2a3-1be6-4024-a68f-1a32ef5efa5f" />
## Why It's Good For The Game
Game no longer yells at you to report a kebab
## Changelog
:cl:
map: fixed a kebab on nebulastation being a basetype
/:cl:
