### PR TITLE
[TG Mirror] Makes Doomsday device minimal APC requirement 10 instead of 15 [MDB IGNORE]

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -158,7 +158,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 		Obtaining control of the weapon will be easier if Head of Staff office APCs are already under your control."
 	cost = 130
 	one_purchase = TRUE
-	minimum_apcs = 15 // So you cant speedrun delta
+	minimum_apcs = 10 // So you cant speedrun delta
 	power_type = /datum/action/innate/ai/nuke_station
 	unlock_text = span_notice("You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.")
 	///List of areas that grant discounts. "heads_quarters" will match any head of staff office.


### PR DESCRIPTION
Original PR: 93566
-----
## About The Pull Request

title

## Why It's Good For The Game

original PR author words
<img width="492" height="79" alt="image" src="https://github.com/user-attachments/assets/a27df1bc-bde8-4799-897f-1d1ba35144ee" />

anyways it takes AGES to hack all 15 APCs, and that's including if you're roundstart malf and hacking APC non-stop. every APC takes 1 minute to hack PLUS additional time for each.

## Changelog


:cl:
balance: Minimal hacked APC amount for purchasing doomsday module was lowered from 15 to 10.
/:cl: