### PR TITLE
[TG Mirror] Changez vomit drinking from checking for flyperzon to checking for fly mouth [MDB IGNORE]

### DIFF
--- a/code/game/objects/effects/decals/cleanable/mess.dm
+++ b/code/game/objects/effects/decals/cleanable/mess.dm
@@ -194,7 +194,8 @@
 	if(. || !ishuman(user))
 		return
 	var/mob/living/carbon/human/as_human = user
-	if(!isflyperson(as_human))
+	var/obj/item/organ/tongue/user_tongue = user.get_organ_slot(ORGAN_SLOT_TONGUE)
+	if(!istype(user_tongue, /obj/item/organ/tongue/fly))
 		return
 	playsound(get_turf(src), 'sound/items/drink.ogg', 50, TRUE) //slurp
 	as_human.visible_message(span_alert("[as_human] extends a small proboscis into the vomit pool, sucking it with a slurping sound."))


### PR DESCRIPTION
Original PR: 93554
-----

## About The Pull Request
Changes the vomit drinking check to check the mob's mouth instead of species. (You still need a flyperson stomach to turn food into vomit)
## Why It's Good For The Game
Being a dizzzguzzzting freak of tele-zzzcience doezzzn't only mean being a buzzing eyezore of a menaze to the ztation. One azzpect of thizzz izz the way one feedz. You uzze your teeth to chew your food, a fly should thuzz use their probozziz to zuck up their food, not their ztatuz as a flyperzzon to do it (even when they are mizzing a fly mouth!). Thiz also makez the interaction fit better with the action dezzcription for it.
## Changelog
:cl:
balance: Vomit drinking now checks for fly mouth instead of fly species
/:cl:
