### PR TITLE
[TG Mirror] Prosthetic Item arms no longer prevent ventcrawling: the remake [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -119,3 +119,7 @@
 #define INCLUDE_POCKETS (1<<0)
 #define INCLUDE_ACCESSORIES (1<<1)
 #define INCLUDE_HELD (1<<2)
+/// Include prosthetic item limbs (which are not flavoured as being equipped items)
+#define INCLUDE_PROSTHETICS (1<<3)
+/// Include items that are not "real" items, such as hand items
+#define INCLUDE_ABSTRACT (1<<4)

--- a/code/_onclick/click_alt.dm
+++ b/code/_onclick/click_alt.dm
@@ -127,8 +127,8 @@
 		return FALSE
 
 	/// No loot panel if it's on our person
-	if(isobj(target) && (target in get_all_gear()))
-		to_chat(src, span_warning("You can't search for this item, it's already in your inventory! Take it off first."))
+	if(isobj(target) && (target in get_all_gear(INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT|INCLUDE_ACCESSORIES)))
+		to_chat(src, span_warning("You can't search for this item, it's already in your inventory![!HAS_TRAIT(target, TRAIT_NODROP) ? " Take it off first." : ""]"))
 		return FALSE
 
 	client.loot_panel.open(get_turf(target))

--- a/code/datums/components/connect_inventory.dm
+++ b/code/datums/components/connect_inventory.dm
@@ -32,7 +32,7 @@
 /datum/component/connect_inventory/proc/update_signals()
 	unregister_signals()
 
-	for(var/obj/item/item as anything in tracked.get_equipped_items(INCLUDE_POCKETS | INCLUDE_HELD))
+	for(var/obj/item/item as anything in tracked.get_equipped_items(INCLUDE_POCKETS|INCLUDE_HELD|INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT))
 		if(!(allowed_slots & tracked.get_slot_by_item(item)))
 			continue
 		RegisterSignal(item, COMSIG_ITEM_DROPPED, PROC_REF(on_unequipped_item))
@@ -40,7 +40,7 @@
 			parent.RegisterSignal(item, signal, connections[signal])
 
 /datum/component/connect_inventory/proc/unregister_signals()
-	for(var/obj/item/item as anything in tracked.get_equipped_items(INCLUDE_POCKETS | INCLUDE_HELD))
+	for(var/obj/item/item as anything in tracked.get_equipped_items(INCLUDE_POCKETS|INCLUDE_HELD|INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT))
 		UnregisterSignal(item, COMSIG_ITEM_DROPPED)
 		parent.UnregisterSignal(item, connections)
 

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -281,7 +281,7 @@
 	owner.clear_mood_event("on_fire")
 	SEND_SIGNAL(owner, COMSIG_LIVING_EXTINGUISHED, owner)
 	cache_stacks()
-	for(var/obj/item/equipped in (owner.get_equipped_items(INCLUDE_HELD)))
+	for(var/obj/item/equipped as anything in owner.get_equipped_items(INCLUDE_HELD|INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT))
 		equipped.extinguish()
 
 /datum/status_effect/fire_handler/fire_stacks/on_remove()

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -355,7 +355,7 @@
 		if(4)
 			//Destroy Equipment
 			selected_turf.visible_message(span_userdanger("Everything [user] is holding and wearing disappears!"))
-			var/list/belongings = user.get_all_gear()
+			var/list/belongings = user.get_all_gear(NONE) //don't delete prosthetics or abstract items.
 			QDEL_LIST(belongings)
 		if(5)
 			//Monkeying

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -400,7 +400,7 @@
 	var/bagholdingcheck = FALSE
 	if(iscarbon(user))
 		var/mob/living/carbon/teleporting_guy = user
-		if(locate(/obj/item/storage/backpack/holding) in teleporting_guy.get_all_gear())
+		if(locate(/obj/item/storage/backpack/holding) in teleporting_guy.get_all_gear(INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT|INCLUDE_ACCESSORIES))
 			bagholdingcheck = TRUE
 
 	if(isclosedturf(destination))

--- a/code/modules/loadout/loadout_helpers.dm
+++ b/code/modules/loadout/loadout_helpers.dm
@@ -36,7 +36,7 @@
 	if(!equipped_outfit.equip(src, visuals_only))
 		return FALSE
 	// Handle any snowflake on_equips
-	var/list/new_contents = get_all_gear()
+	var/list/new_contents = get_all_gear(INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT|INCLUDE_ACCESSORIES)
 	var/update = NONE
 	for(var/datum/loadout_item/item as anything in loadout_datums)
 		update |= item.on_equip_item(

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -95,8 +95,14 @@
 /mob/proc/get_num_held_items()
 	. = 0
 	for(var/i in 1 to held_items.len)
-		if(held_items[i])
-			.++
+		if(!held_items[i])
+			continue
+		var/obj/item/gripped_item = held_items[i]
+		if(HAS_TRAIT_FROM(gripped_item, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)) //prostetic limbs are not held items, they are part of the body.
+			continue
+		if(gripped_item.item_flags & ABSTRACT) //not really flavoured as items
+			continue
+		.++
 
 //Sad that this will cause some overhead, but the alias seems necessary
 //*I* may be happy with a million and one references to "indexes" but others won't be
@@ -451,9 +457,14 @@
 	var/list/items = list()
 	for(var/obj/item/item_contents in contents)
 		if(item_contents.item_flags & IN_INVENTORY)
+			if(!(include_flags & INCLUDE_PROSTHETICS) && HAS_TRAIT_FROM(item_contents, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)) //prostetic limbs are not equipped items, they are part of the body.
+				continue
+			if(!(include_flags & INCLUDE_ABSTRACT) && (item_contents.item_flags & ABSTRACT)) //not really flavoured as items
+				continue
 			items += item_contents
 	if (!(include_flags & INCLUDE_HELD))
 		items -= held_items
+
 	return items
 
 /**
@@ -652,8 +663,8 @@
 		hud_used.build_hand_slots()
 
 //GetAllContents that is reasonable and not stupid
-/mob/living/proc/get_all_gear(accessories = TRUE, recursive = TRUE)
-	var/list/processing_list = get_equipped_items(INCLUDE_POCKETS | INCLUDE_HELD | (accessories ? INCLUDE_ACCESSORIES : NONE))
+/mob/living/proc/get_all_gear(equipment_flags = INCLUDE_ACCESSORIES|INCLUDE_PROSTHETICS, recursive = TRUE)
+	var/list/processing_list = get_equipped_items(INCLUDE_POCKETS|INCLUDE_HELD|equipment_flags)
 	list_clear_nulls(processing_list) // handles empty hands
 	var/i = 0
 	while(i < length(processing_list))
@@ -663,8 +674,8 @@
 	return processing_list
 
 /// Returns a list of things that the provided mob has, including any storage-capable implants.
-/mob/living/proc/gather_belongings(accessories = TRUE, recursive = TRUE)
-	var/list/belongings = get_all_gear(accessories, recursive)
+/mob/living/proc/gather_belongings(equipment_flags = INCLUDE_ACCESSORIES|INCLUDE_PROSTHETICS, recursive = TRUE)
+	var/list/belongings = get_all_gear(equipment_flags, recursive)
 	for (var/obj/item/implant/storage/internal_bag in implants)
 		belongings += internal_bag.contents
 	return belongings
@@ -673,7 +684,7 @@
 /mob/living/proc/drop_everything(del_on_drop, force, del_if_nodrop)
 	. = list() //list of items that were successfully dropped
 
-	var/list/all_gear = get_all_gear(recursive = FALSE)
+	var/list/all_gear = get_all_gear(INCLUDE_ACCESSORIES, recursive = FALSE)
 	for(var/obj/item/item in all_gear)
 		if(dropItemToGround(item, force))
 			if(QDELETED(item)) //DROPDEL can cause this item to be deleted
@@ -682,7 +693,7 @@
 				qdel(item)
 				continue
 			. += item
-		else if(del_if_nodrop && !(item.item_flags & ABSTRACT))
+		else if(del_if_nodrop)
 			qdel(item)
 
 /**

--- a/code/modules/mob/living/basic/bots/hygienebot/hygienebot_ai.dm
+++ b/code/modules/mob/living/basic/bots/hygienebot/hygienebot_ai.dm
@@ -86,7 +86,7 @@
 			found_target = wash_potential
 			break
 
-		for(var/atom/clothing in wash_potential.get_equipped_items())
+		for(var/atom/clothing in wash_potential.get_equipped_items(INCLUDE_HELD|INCLUDE_PROSTHETICS))
 			if(GET_ATOM_BLOOD_DNA_LENGTH(clothing))
 				found_target = wash_potential
 				break

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -512,7 +512,7 @@
  */
 /mob/living/carbon/proc/update_tint()
 	var/tint = 0
-	for(var/obj/item/clothing/worn_item in get_equipped_items())
+	for(var/obj/item/clothing/worn_item in get_equipped_items(INCLUDE_ABSTRACT))
 		tint += worn_item.tint
 
 	var/obj/item/organ/eyes/eyes = get_organ_slot(ORGAN_SLOT_EYES)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -56,7 +56,7 @@
 	return null
 
 /mob/living/carbon/is_ears_covered()
-	for(var/obj/item/worn_thing as anything in get_equipped_items())
+	for(var/obj/item/worn_thing as anything in get_equipped_items(INCLUDE_ABSTRACT))
 		if(worn_thing.flags_cover & EARS_COVERED)
 			return worn_thing
 

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -45,7 +45,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 //Instead of just deleting our equipment, we save what we can and reinsert it into SSwardrobe's store
 //Hopefully this makes preference reloading not the worst thing ever
 /mob/living/carbon/human/dummy/delete_equipment()
-	var/list/items_to_check = get_equipped_items(INCLUDE_POCKETS | INCLUDE_HELD)
+	var/list/items_to_check = get_equipped_items(INCLUDE_POCKETS|INCLUDE_HELD|INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT)
 	var/list/to_nuke = list() //List of items queued for deletion, can't qdel them before iterating their contents in case they hold something
 	///Travel to the bottom of the contents chain, expanding it out
 	for(var/i = 1; i <= length(items_to_check); i++) //Needs to be a c style loop since it can expand

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1062,7 +1062,7 @@
 	var/chest_covered = FALSE
 	var/head_covered = FALSE
 	var/hands_covered = FALSE
-	for (var/obj/item/clothing/equipped in get_equipped_items())
+	for (var/obj/item/clothing/equipped in get_equipped_items(INCLUDE_ABSTRACT))
 		// We don't really have space-proof gloves, so even if we're checking them we ignore the flags
 		if ((equipped.body_parts_covered & HANDS) && num_hands >= default_num_hands)
 			hands_covered = TRUE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -34,7 +34,7 @@
 ///Get all the clothing on a specific body part
 /mob/living/carbon/human/proc/get_clothing_on_part(obj/item/bodypart/def_zone)
 	var/list/covering_part = list()
-	for(var/obj/item/clothing/equipped in get_equipped_items())
+	for(var/obj/item/clothing/equipped in get_equipped_items(INCLUDE_ABSTRACT))
 		if(equipped.body_parts_covered & def_zone.body_part)
 			covering_part += equipped
 	return covering_part
@@ -85,7 +85,7 @@
 		return SUCCESSFUL_BLOCK
 
 	var/block_chance_modifier = round(damage / -3)
-	for(var/obj/item/worn_thing in get_equipped_items(INCLUDE_HELD))
+	for(var/obj/item/worn_thing in get_equipped_items(INCLUDE_HELD|INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT))
 		// Things that are supposed to be worn, being held = cannot block
 		if(isclothing(worn_thing))
 			if(worn_thing in held_items)

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -907,7 +907,7 @@ generate/load female uniform sprites matching all previously decided variables
 	// hardcoding this here until bodypart updating is more sane
 	// we need to update clothing items that may have been affected by bodyshape updates
 	if(check_shapes & BODYSHAPE_DIGITIGRADE)
-		for(var/obj/item/thing as anything in get_equipped_items())
+		for(var/obj/item/thing as anything in get_equipped_items(INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT))
 			if(thing.slot_flags & ignore_slots)
 				continue
 			if(thing.supports_variations_flags & DIGITIGRADE_VARIATIONS)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -349,7 +349,7 @@
 
 //delete all equipment without dropping anything
 /mob/living/carbon/human/proc/delete_equipment()
-	for(var/slot in get_equipped_items(INCLUDE_POCKETS))//order matters, dependant slots go first
+	for(var/slot in get_equipped_items(INCLUDE_POCKETS|INCLUDE_HELD))//order matters, dependant slots go first
 		qdel(slot)
 	for(var/obj/item/held_item in held_items)
 		qdel(held_item)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -54,7 +54,7 @@
 	var/head_covered = !get_bodypart(BODY_ZONE_HEAD)
 	var/hands_covered = !get_bodypart(BODY_ZONE_L_ARM) && !get_bodypart(BODY_ZONE_R_ARM)
 	var/feet_covered = !get_bodypart(BODY_ZONE_L_LEG) && !get_bodypart(BODY_ZONE_R_LEG)
-	for(var/obj/item/clothing/equipped in get_equipped_items())
+	for(var/obj/item/clothing/equipped in get_equipped_items(INCLUDE_ABSTRACT))
 		if(!chest_covered && (equipped.body_parts_covered & CHEST) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))
 			chest_covered = TRUE
 		if(!head_covered && (equipped.body_parts_covered & HEAD) && (equipped.clothing_flags & STOPSPRESSUREDAMAGE))

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -65,9 +65,7 @@
 /mob/living/carbon/proc/get_visible_items()
 	var/list/visible_items = list()
 	var/obscured_item_slots = hidden_slots_to_inventory_slots(obscured_slots)
-	for (var/obj/item/held in held_items)
-		visible_items += held
-	for(var/obj/item/thing in get_equipped_items())
+	for(var/obj/item/thing in get_equipped_items(INCLUDE_HELD|INCLUDE_PROSTHETICS))
 		if(!(get_slot_by_item(thing) & obscured_item_slots))
 			visible_items += thing
 	return visible_items
@@ -166,7 +164,7 @@
 	return not_handled
 
 /mob/living/carbon/get_equipped_speed_mod_items()
-	return ..() + get_equipped_items()
+	return ..() + get_equipped_items(INCLUDE_ABSTRACT)
 
 /mob/living/carbon/has_equipped(obj/item/item, slot, initial = FALSE)
 	. = ..()
@@ -426,7 +424,7 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 
 	var/covered_flags = NONE
-	var/list/all_worn_items = get_equipped_items()
+	var/list/all_worn_items = get_equipped_items(INCLUDE_ABSTRACT)
 	for(var/obj/item/worn_item in all_worn_items)
 		covered_flags |= worn_item.body_parts_covered
 
@@ -437,7 +435,7 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 
 	var/covered_flags = NONE
-	var/list/all_worn_items = get_equipped_items()
+	var/list/all_worn_items = get_equipped_items(INCLUDE_ABSTRACT)
 	for(var/obj/item/worn_item in all_worn_items)
 		covered_flags |= worn_item.body_parts_covered
 

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -46,7 +46,7 @@
 			to_chat(src, span_warning("You can't vent crawl while buckled!"))
 		return
 	if(iscarbon(src) && required_nudity)
-		if(length(get_equipped_items(INCLUDE_POCKETS)) || get_num_held_items())
+		if(length(get_equipped_items(INCLUDE_POCKETS|INCLUDE_HELD)))
 			if(provide_feedback)
 				to_chat(src, span_warning("You can't crawl around in the ventilation ducts with items!"))
 			return

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -500,7 +500,7 @@
 	var/list/things_to_disrupt = list(target)
 	if(isliving(target))
 		var/mob/living/live_target = target
-		things_to_disrupt += live_target.get_all_gear()
+		things_to_disrupt += live_target.get_all_gear(INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT|INCLUDE_ACCESSORIES)
 
 	for(var/atom/disrupted as anything in things_to_disrupt)
 		if(disrupted.on_saboteur(src, 1 MINUTES))

--- a/code/modules/projectiles/projectile/special/saboteur.dm
+++ b/code/modules/projectiles/projectile/special/saboteur.dm
@@ -21,7 +21,7 @@
 	var/list/things_to_disrupt = list(target)
 	if(isliving(target))
 		var/mob/living/live_target = target
-		things_to_disrupt += live_target.get_all_gear()
+		things_to_disrupt += live_target.get_all_gear(INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT|INCLUDE_ACCESSORIES)
 
 	var/success = FALSE
 	for(var/atom/disrupted as anything in things_to_disrupt)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -1255,7 +1255,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/picked_color = pick(random_color_list)
 	var/color_filter = color_transition_filter(picked_color, SATURATION_OVERRIDE)
 	if (can_color_clothing && (methods & (TOUCH|VAPOR|INHALE)))
-		var/include_flags = INCLUDE_HELD|INCLUDE_ACCESSORIES
+		var/include_flags = INCLUDE_HELD|INCLUDE_ACCESSORIES|INCLUDE_PROSTHETICS|INCLUDE_ABSTRACT
 		if (methods & (VAPOR|INHALE) || touch_protection >= 1)
 			include_flags |= INCLUDE_POCKETS
 		for (var/obj/item/to_color in exposed_mob.get_equipped_items(include_flags))

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -10,7 +10,7 @@
 	facial_hair_hidden = FALSE
 	LAZYNULL(hair_masks)
 	if(human_head_owner)
-		for(var/obj/item/worn_item in human_head_owner.get_equipped_items())
+		for(var/obj/item/worn_item in human_head_owner.get_equipped_items(INCLUDE_ABSTRACT))
 			if(worn_item.hair_mask)
 				LAZYSET(hair_masks, worn_item.hair_mask, TRUE)
 		hair_hidden = !!(human_head_owner.obscured_slots & HIDEHAIR)

--- a/code/modules/unit_tests/outfit_sanity.dm
+++ b/code/modules/unit_tests/outfit_sanity.dm
@@ -49,7 +49,7 @@
 
 	for (var/outfit_type in outfits_to_check)
 		// Only make one human and keep undressing it because it's much faster
-		for (var/obj/item/I in H.get_equipped_items(INCLUDE_POCKETS))
+		for (var/obj/item/I in H.get_equipped_items(INCLUDE_POCKETS|INCLUDE_ABSTRACT))
 			qdel(I)
 
 		var/datum/outfit/outfit = new outfit_type

--- a/code/modules/unit_tests/screenshot_digi.dm
+++ b/code/modules/unit_tests/screenshot_digi.dm
@@ -67,7 +67,7 @@
 	// finally, screenshot test of taking jumpsuit (everything) off
 	// which should test that the autogen legs disappear (here to cover a bug in which it does not disappear)
 	dummy.delete_equipment()
-	TEST_ASSERT_EQUAL(length(dummy.get_equipped_items()), 0, "Dummy (Ashwalker) should have no equipment!")
+	TEST_ASSERT_EQUAL(length(dummy.get_equipped_items(INCLUDE_POCKETS|INCLUDE_HELD)), 0, "Dummy (Ashwalker) should have no equipment!")
 	finished_icon = icon(finished_icon)
 	finished_icon.Insert(getFlatIcon(dummy, no_anim = TRUE), dir = SOUTH, frame = 9)
 

--- a/code/modules/wiremod/core/marker.dm
+++ b/code/modules/wiremod/core/marker.dm
@@ -56,7 +56,7 @@
 		carbon_target = target
 		visible_items = carbon_target.get_visible_items()
 	else
-		visible_items = target.get_equipped_items()
+		visible_items = target.get_equipped_items(INCLUDE_HELD)
 
 	visible_items -= src // the multitool cannot mark itself.
 
@@ -89,7 +89,7 @@
 		return
 
 	var/atom/movable/chosen = locate(picked_ref)
-	if(chosen == target || (chosen in (carbon_target ? carbon_target.get_visible_items() : target.get_equipped_items())))
+	if(chosen == target || (chosen in (carbon_target ? carbon_target.get_visible_items() : target.get_equipped_items(INCLUDE_HELD))))
 		mark_target(chosen)
 	else
 		balloon_alert(user, "cannot mark entity")


### PR DESCRIPTION
Original PR: 93499
-----
## About The Pull Request
This is me picking up #93077 but with code changes relative to the two new flags that Krysonism added in his PR, which unfortunately he never finished.

## Why It's Good For The Game
Monkeys should be able to ventcrawl even if their left or right arm is actually a chainsaw or armblade or whatever. See #93077 

## Changelog
:cl: Krysonism
balance: prosthetic item limbs are no longer considered equipped items for some purposes such as ventcrawling.
/:cl:
