### PR TITLE
[TG Mirror] Fixes dropped limbs rotating and disappearing when pulled/thrown [MDB IGNORE]

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -1101,42 +1101,43 @@
 	if(dropped && dmg_overlay_type)
 		if(brutestate)
 			// divided into two overlays: one that gets colored and one that doesn't.
-			var/image/brute_blood_overlay = image('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_[brutestate]0", -DAMAGE_LAYER)
+			var/image/brute_blood_overlay = image('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_[brutestate]0", -DAMAGE_LAYER, dir = SOUTH)
 			brute_blood_overlay.color = get_color_from_blood_list(update_on ? update_on.get_blood_dna_list() : blood_dna_info) // living mobs can just get it fresh, dropped limbs use blood_dna_info
 			var/mutable_appearance/brute_damage_overlay = mutable_appearance('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_[brutestate]0_overlay", -DAMAGE_LAYER, appearance_flags = RESET_COLOR)
 			if(brute_damage_overlay)
 				brute_blood_overlay.overlays += brute_damage_overlay
 			. += brute_blood_overlay
 		if(burnstate)
-			. += image('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_0[burnstate]", -DAMAGE_LAYER)
+			. += image('icons/mob/effects/dam_mob.dmi', "[dmg_overlay_type]_[body_zone]_0[burnstate]", -DAMAGE_LAYER, dir = SOUTH)
 
-	var/image/limb = image(layer = -BODYPARTS_LAYER)
-	var/image/aux
+	var/image_dir = null
+	if (dropped)
+		image_dir = SOUTH
 
 	// Handles invisibility (not alpha or actual invisibility but invisibility)
 	if(is_invisible)
-		limb.icon = icon_invisible
-		limb.icon_state = "invisible_[body_zone]"
-		. += limb
+		. += image(icon_invisible, "invisible_[body_zone]", -BODYPARTS_LAYER, dir = image_dir)
 		return .
 
 	// Normal non-husk handling
-		// This is the MEAT of limb icon code
-	limb.icon = icon_greyscale
+	// This is the MEAT of limb icon code
+	var/used_icon = icon_greyscale
 	if(!should_draw_greyscale || !icon_greyscale)
-		limb.icon = icon_static
+		used_icon = icon_static
 
-	if(is_dimorphic) //Does this type of limb have sexual dimorphism?
-		limb.icon_state = "[limb_id]_[body_zone]_[limb_gender]"
-	else
-		limb.icon_state = "[limb_id]_[body_zone]"
+	var/used_state = "[limb_id]_[body_zone]"
+	if(is_dimorphic) // Does this type of limb have sexual dimorphism?
+		used_state = "[limb_id]_[body_zone]_[limb_gender]"
+
+	var/image/limb = image(used_icon, used_state, -BODYPARTS_LAYER, dir = image_dir)
+	var/image/aux = null
 
 	icon_exists_or_scream(limb.icon, limb.icon_state) //Prints a stack trace on the first failure of a given iconstate.
 
 	. += limb
 
 	if(aux_zone) //Hand shit
-		aux = image(limb.icon, "[limb_id]_[aux_zone]", -aux_layer)
+		aux = image(limb.icon, "[limb_id]_[aux_zone]", -aux_layer, dir = image_dir)
 		. += aux
 
 	if(is_husked)
@@ -1152,50 +1153,67 @@
 		if(aux_zone)
 			aux.color = "[draw_color]"
 
-	//EMISSIVE CODE START
-	// For some reason this was applied as an overlay on the aux image and limb image before.
-	// I am very sure that this is unnecessary, and i need to treat it as part of the return list
-	// to be able to mask it proper in case this limb is a leg.
 	var/atom/location = loc || owner || src
 	if(blocks_emissive != EMISSIVE_BLOCK_NONE)
 		var/mutable_appearance/limb_em_block = emissive_blocker(limb.icon, limb.icon_state, location, layer = limb.layer, alpha = limb.alpha)
+		if (dropped)
+			limb_em_block = image(limb_em_block, dir = SOUTH)
 		. += limb_em_block
 
 		if(aux_zone)
 			var/mutable_appearance/aux_em_block = emissive_blocker(aux.icon, aux.icon_state, location, layer = aux.layer, alpha = aux.alpha)
+			if (dropped)
+				aux_em_block = image(aux_em_block, dir = SOUTH)
 			. += aux_em_block
 
 	if(!is_husked && is_emissive)
 		var/mutable_appearance/limb_em = emissive_appearance(limb.icon, "[limb.icon_state]_e", location, layer = limb.layer, alpha = limb.alpha)
+		if (dropped)
+			limb_em = image(limb_em, dir = SOUTH)
 		. += limb_em
 
 		if(aux_zone)
 			var/mutable_appearance/aux_em = emissive_appearance(aux.icon, "[aux.icon_state]_e", location, layer = aux.layer, alpha = aux.alpha)
+			if (dropped)
+				aux_em = image(aux_em, dir = SOUTH)
 			. += aux_em
-	//EMISSIVE CODE END
 
-	//No need to handle leg layering if dropped, we only face south anyways
+	// No need to handle leg layering if dropped, we only face south anyways
 	if(!dropped && ((body_zone == BODY_ZONE_R_LEG) || (body_zone == BODY_ZONE_L_LEG)))
-		//Legs are a bit goofy in regards to layering, and we will need two images instead of one to fix that
+		// Legs are a bit goofy in regards to layering, and we will need two images instead of one to fix that
 		var/obj/item/bodypart/leg/leg_source = src
 		for(var/image/limb_image in .)
-			//remove the old, unmasked image
+			// Remove the old, unmasked image
 			. -= limb_image
-			//add two masked images based on the old one
+			// Add two masked images based on the old one
 			. += leg_source.generate_masked_leg(limb_image)
 
 	// And finally put bodypart_overlays on if not husked
 	if(is_husked)
 		return .
 
-	//Draw external organs like horns and frills
+	// Draw external organs like horns and frills
 	for(var/datum/bodypart_overlay/overlay as anything in bodypart_overlays)
 		if(!overlay.can_draw_on_bodypart(src, owner))
 			continue
-		//Some externals have multiple layers for background, foreground and between
+
+		// Some externals have multiple layers for background, foreground and between
 		for(var/external_layer in overlay.all_layers)
-			if(overlay.layers & external_layer)
-				. += overlay.get_overlay(external_layer, src)
+			if(!(overlay.layers & external_layer))
+				continue
+
+			var/external_overlay = overlay.get_overlay(external_layer, src)
+			if (!dropped)
+				. += external_overlay
+				continue
+
+			if (!islist(external_overlay))
+				. += image(external_overlay, dir = SOUTH)
+				continue
+
+			for (var/mutable_appearance/actual_overlay as anything in external_overlay)
+				. += image(actual_overlay, dir = SOUTH)
+
 		for(var/datum/layer in .)
 			overlay.modify_bodypart_appearance(layer)
 	return .

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -173,9 +173,9 @@
 
 /obj/item/bodypart/head/get_limb_icon(dropped, mob/living/carbon/update_on)
 	. = ..()
-
 	. += get_hair_and_lips_icon(dropped)
 	// We need to get the eyes if we are dropped (ugh)
+<<<<<<< HEAD
 	if(dropped)
 		var/obj/item/organ/eyes/eyes = locate(/obj/item/organ/eyes) in src
 		// This is a bit of copy/paste code from eyes.dm:generate_body_overlay
@@ -205,6 +205,46 @@
 			. += no_eyes
 
 	return
+=======
+	if(!dropped)
+		return
+
+	var/obj/item/organ/eyes/eyes = locate(/obj/item/organ/eyes) in src
+	if(!eyes)
+		if (!(head_flags & HEAD_EYEHOLES))
+			return
+		var/image/no_eyes = image('icons/mob/human/human_face.dmi', "eyes_missing", -EYES_LAYER, SOUTH)
+		worn_face_offset?.apply_offset(no_eyes)
+		. += no_eyes
+		return
+
+	if(!eyes.eye_icon_state || !(head_flags & HEAD_EYESPRITES))
+		return
+
+	// This is a bit of copy/paste code from eyes.dm:generate_body_overlay
+	var/image/eye_left = image('icons/mob/human/human_face.dmi', "[eyes.eye_icon_state]_l", -EYES_LAYER, SOUTH)
+	var/image/eye_right = image('icons/mob/human/human_face.dmi', "[eyes.eye_icon_state]_r", -EYES_LAYER, SOUTH)
+	if(head_flags & HEAD_EYECOLOR)
+		if(eyes.eye_color_left)
+			eye_left.color = eyes.eye_color_left
+		if(eyes.eye_color_right)
+			eye_right.color = eyes.eye_color_right
+
+	var/list/emissive_overlays = eyes.get_emissive_overlays(eye_left, eye_right, src)
+	if(length(emissive_overlays))
+		eye_left.overlays += image(emissive_overlays[1], dir = SOUTH)
+		eye_right.overlays += image(emissive_overlays[2], dir = SOUTH)
+	else if(blocks_emissive != EMISSIVE_BLOCK_NONE)
+		eye_left.overlays += image(emissive_blocker(eye_left.icon, eye_left.icon_state, src, alpha = eye_left.alpha), dir = SOUTH)
+		eye_right.overlays += image(emissive_blocker(eye_right.icon, eye_right.icon_state, src, alpha = eye_right.alpha), dir = SOUTH)
+
+	if(worn_face_offset)
+		worn_face_offset.apply_offset(eye_left)
+		worn_face_offset.apply_offset(eye_right)
+
+	. += eye_left
+	. += eye_right
+>>>>>>> d402e20632d (Fixes dropped limbs rotating and disappearing when pulled/thrown (#93521))
 
 /obj/item/bodypart/head/Initialize(mapload)
 	. = ..()

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -62,16 +62,16 @@
 	. = list()
 
 	var/atom/location = loc || owner || src
+	var/image_dir = null
+	if (dropped)
+		image_dir = SOUTH
 
 	var/datum/sprite_accessory/sprite_accessory
 	if(!facial_hair_hidden && lip_style && (head_flags & HEAD_LIPS))
 		//not a sprite accessory, don't ask
 		//Overlay
-		var/image/lip_overlay = image('icons/mob/human/human_face.dmi', "lips_[lip_style]", -BODY_LAYER)
+		var/image/lip_overlay = image('icons/mob/human/human_face.dmi', "lips_[lip_style]", -BODY_LAYER, dir = image_dir)
 		lip_overlay.color = lip_color
-		//Emissive blocker
-		if(blocks_emissive != EMISSIVE_BLOCK_NONE)
-			lip_overlay.overlays += emissive_blocker(lip_overlay.icon, lip_overlay.icon_state, location, alpha = facial_hair_alpha)
 		//Offsets
 		worn_face_offset?.apply_offset(lip_overlay)
 		. += lip_overlay
@@ -81,11 +81,14 @@
 		sprite_accessory = SSaccessories.facial_hairstyles_list[facial_hairstyle]
 		if(sprite_accessory)
 			//Overlay
-			facial_hair_overlay = image(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER)
+			facial_hair_overlay = image(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER, dir = image_dir)
 			facial_hair_overlay.alpha = facial_hair_alpha
 			//Emissive blocker
 			if(blocks_emissive != EMISSIVE_BLOCK_NONE)
-				facial_hair_overlay.overlays += emissive_blocker(facial_hair_overlay.icon, facial_hair_overlay.icon_state, location, alpha = facial_hair_alpha)
+				var/mutable_appearance/em_block = emissive_blocker(facial_hair_overlay.icon, facial_hair_overlay.icon_state, location, alpha = facial_hair_alpha)
+				if (dropped)
+					em_block = image(em_block, dir = SOUTH)
+				facial_hair_overlay.overlays += em_block
 			//Offsets
 			worn_face_offset?.apply_offset(facial_hair_overlay)
 			. += facial_hair_overlay
@@ -93,7 +96,7 @@
 			var/facial_hair_gradient_style = gradient_styles[GRADIENT_FACIAL_HAIR_KEY]
 			if(facial_hair_gradient_style != "None")
 				var/facial_hair_gradient_color = gradient_colors[GRADIENT_FACIAL_HAIR_KEY]
-				var/image/facial_hair_gradient_overlay = get_gradient_overlay(icon(sprite_accessory.icon, sprite_accessory.icon_state), -HAIR_LAYER, SSaccessories.facial_hair_gradients_list[facial_hair_gradient_style], facial_hair_gradient_color)
+				var/image/facial_hair_gradient_overlay = get_gradient_overlay(icon(sprite_accessory.icon, sprite_accessory.icon_state), -HAIR_LAYER, SSaccessories.facial_hair_gradients_list[facial_hair_gradient_style], facial_hair_gradient_color, dropped)
 				. += facial_hair_gradient_overlay
 
 	var/list/all_hair_overlays = list()
@@ -103,7 +106,7 @@
 			//Hair masks
 			var/icon/base_icon = icon(hair_sprite_accessory.getCachedIcon(hair_masks))
 			//Overlay
-			all_hair_overlays += image(base_icon, layer=-HAIR_LAYER)
+			all_hair_overlays += image(base_icon, layer=-HAIR_LAYER, dir = image_dir)
 			//If we have any hair appendages (ponytails, etc.) sticking out on a particular side, we need to add an additional hair layer to go above hats/helmets for the sides they stick out on
 			if(LAZYLEN(hair_sprite_accessory.hair_appendages_outer))
 				var/strictly_masked_zones = NONE
@@ -112,13 +115,16 @@
 				for(var/appendage_icon_state in hair_sprite_accessory.hair_appendages_outer)
 					var/appendage_zone = hair_sprite_accessory.hair_appendages_outer[appendage_icon_state]
 					if(!(appendage_zone & strictly_masked_zones)) // if there are no strict masks in this zone
-						all_hair_overlays += image(hair_sprite_accessory.icon, icon_state=appendage_icon_state, layer=-OUTER_HAIR_LAYER)
+						all_hair_overlays += image(hair_sprite_accessory.icon, icon_state=appendage_icon_state, layer=-OUTER_HAIR_LAYER, dir = image_dir)
 			for(var/image/hair_overlay as anything in all_hair_overlays)
 				hair_overlay.alpha = hair_alpha
 				hair_overlay.pixel_z = hair_sprite_accessory.y_offset
 				//Emissive blocker
 				if(blocks_emissive != EMISSIVE_BLOCK_NONE)
-					hair_overlay.overlays += emissive_blocker(hair_overlay.icon, hair_overlay.icon_state, location, alpha = hair_alpha)
+					var/mutable_appearance/em_block = emissive_blocker(hair_overlay.icon, hair_overlay.icon_state, location, alpha = hair_alpha)
+					if (dropped)
+						em_block = image(em_block, dir = SOUTH)
+					hair_overlay.overlays += em_block
 				//Offsets
 				worn_face_offset?.apply_offset(hair_overlay)
 				. += hair_overlay
@@ -126,15 +132,15 @@
 				var/hair_gradient_style = gradient_styles[GRADIENT_HAIR_KEY]
 				if(hair_gradient_style != "None")
 					var/hair_gradient_color = gradient_colors[GRADIENT_HAIR_KEY]
-					var/image/hair_gradient_overlay = get_gradient_overlay(base_icon, hair_overlay.layer, SSaccessories.hair_gradients_list[hair_gradient_style], hair_gradient_color)
+					var/image/hair_gradient_overlay = get_gradient_overlay(base_icon, hair_overlay.layer, SSaccessories.hair_gradients_list[hair_gradient_style], hair_gradient_color, dropped)
 					hair_gradient_overlay.pixel_z = hair_sprite_accessory.y_offset
 					. += hair_gradient_overlay
 
 	if(show_debrained && (head_flags & HEAD_DEBRAIN))
-		. += get_debrain_overlay()
+		. += get_debrain_overlay(dropped)
 
 	if(show_eyeless && (head_flags & HEAD_EYEHOLES))
-		. += get_eyeless_overlay()
+		. += get_eyeless_overlay(dropped)
 
 	//HAIR COLOR START
 	if(override_hair_color)
@@ -156,7 +162,7 @@
 #undef SET_OVERLAY_VALUE
 
 /// Returns an appropriate debrained overlay
-/obj/item/bodypart/head/proc/get_debrain_overlay()
+/obj/item/bodypart/head/proc/get_debrain_overlay(dropped)
 	RETURN_TYPE(/image)
 	var/debrain_icon = 'icons/mob/human/human_face.dmi'
 	var/debrain_icon_state = "debrained"
@@ -171,21 +177,25 @@
 		debrain_icon_state = "debrained"
 
 	var/image/debrain_overlay = mutable_appearance(debrain_icon, debrain_icon_state, -HAIR_LAYER)
+	if (dropped)
+		debrain_overlay = image(debrain_overlay, dir = SOUTH)
 	worn_face_offset?.apply_offset(debrain_overlay)
 	return debrain_overlay
 
 /// Returns an appropriate missing eyes overlay
-/obj/item/bodypart/head/proc/get_eyeless_overlay()
+/obj/item/bodypart/head/proc/get_eyeless_overlay(dropped)
 	RETURN_TYPE(/image)
 	var/eyeless_icon = 'icons/mob/human/human_face.dmi'
 	var/eyeless_icon_state = "eyes_missing"
 
 	var/image/eyeless_overlay = mutable_appearance(eyeless_icon, eyeless_icon_state, -HAIR_LAYER)
+	if (dropped)
+		eyeless_overlay = image(eyeless_overlay, dir = SOUTH)
 	worn_face_offset?.apply_offset(eyeless_overlay)
 	return eyeless_overlay
 
 /// Returns an appropriate hair/facial hair gradient overlay
-/obj/item/bodypart/head/proc/get_gradient_overlay(icon/base_icon, layer, datum/sprite_accessory/gradient, grad_color)
+/obj/item/bodypart/head/proc/get_gradient_overlay(icon/base_icon, layer, datum/sprite_accessory/gradient, grad_color, dropped)
 	RETURN_TYPE(/mutable_appearance)
 
 	var/mutable_appearance/gradient_overlay = mutable_appearance(layer = layer)
@@ -194,6 +204,8 @@
 	temp.Blend(temp_hair, ICON_ADD)
 	gradient_overlay.icon = temp
 	gradient_overlay.color = grad_color
+	if (dropped)
+		gradient_overlay = image(gradient_overlay, dir = SOUTH)
 	worn_face_offset?.apply_offset(gradient_overlay)
 	return gradient_overlay
 


### PR DESCRIPTION
Original PR: 93521
-----

## About The Pull Request

Closes #92973 by turning all mutable overlays into images with set SOUTH dir if the limb is dropped, thus ensuring nothing rotates when its dragged around

<img width="78" height="75" alt="image" src="https://github.com/user-attachments/assets/307126aa-f268-4dac-b521-4e8f168529b9" />

## Why It's Good For The Game

Our human rendering code is crying in the corner curled up in a fetal position, I wish BYOND just allowed us to ban a whole object from visibly rotating

## Changelog
:cl:
fix: Fixed dropped limbs rotating and disappearing when pulled/thrown
/:cl:
