### PR TITLE
[TG Mirror] Ensures that under no circumstances storage-related harddels can brick HUDs [MDB IGNORE]

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -344,7 +344,12 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 				screenmob.client.screen += infodisplay
 			if(always_visible_inventory.len)
 				screenmob.client.screen += always_visible_inventory
+<<<<<<< HEAD
 			if(open_containers.len)
+=======
+			if(open_containers.len && screenmob == mymob) // Don't show open inventories to ghosts
+				list_clear_nulls(open_containers)
+>>>>>>> 2b8aa4e0eb2 (Ensures that under no circumstances storage-related harddels can brick HUDs (#93559))
 				screenmob.client.screen += open_containers
 			screenmob.client.screen += toggle_palette
 


### PR DESCRIPTION
Original PR: 93559
-----

## About The Pull Request

If something harddels with its reference still in ``open_containers`` due to whatever reasons, it will permanently brick HUDs of anyone who had that storage open until their mob or HUD is reset by admins, rendering the game completely unplayable. I'm not sure what exactly went wrong as ``COMSIG_ATOM_EXITED`` should handle deletions already, but [this runtime log](https://terry-logs.tgstation13.org/2025/10/20/round-257110/runtime.log) contains some info if anyone is willing to poke at the issue more.

I know this technically "silences the real problem" but the issue is harddels caused by storage not being informed of item deletion, its logged as a harddel and shouldn't brick clients while at it.

## Changelog
:cl:
fix: Fixed an issue which could randomly completely break a player's visuals until an admin resets their HUD
/:cl:
