### PR TITLE
[TG Mirror] (2) Changes Wallet Priority: Standard ID cards now go in order properly: from left to right [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -35,7 +35,7 @@
 			is_magnetic_found = TRUE
 
 		if(!is_magnetic_found)
-			var/card_tally = SSid_access.tally_access(id_card, ACCESS_FLAG_COMMAND)
+			var/card_tally = SSid_access.tally_access(id_card, ACCESS_FLAG_PRV_COMMAND)
 			if(card_tally > winning_tally)
 				winning_tally = card_tally
 				front_id = id_card


### PR DESCRIPTION
Original PR: 93575
-----
## About The Pull Request

[previous PR](https://github.com/tgstation/tgstation/pull/93290)
now command ID (silver & gold IDs) priority remain unchanged

example 1
<img width="435" height="105" alt="Screenshot 2025-10-22 112002" src="https://github.com/user-attachments/assets/44868d9c-7487-4a9a-b0d9-c94ff4182f92" />
before
<img width="87" height="87" alt="Screenshot 2025-10-22 111655" src="https://github.com/user-attachments/assets/a4223d03-f03f-43f0-bb54-fc8795fd1fab" />
^ if you were to remove engi id from the wallet above, it will show robotics id (instead of secoff)
^ before this PR, engi IDs even took priority over wardens
after
<img width="88" height="90" alt="Screenshot 2025-10-22 112010" src="https://github.com/user-attachments/assets/a16d508c-4819-4d0a-8316-1372a39a25ff" />


example 2
<img width="426" height="111" alt="Screenshot 2025-10-22 111714" src="https://github.com/user-attachments/assets/fd5b563a-e454-4e0e-be7b-7cfbd9507ca3" />
before
<img width="87" height="87" alt="Screenshot 2025-10-22 111655" src="https://github.com/user-attachments/assets/a4223d03-f03f-43f0-bb54-fc8795fd1fab" />
after
<img width="85" height="85" alt="Screenshot 2025-10-22 111646" src="https://github.com/user-attachments/assets/d6f35891-a29f-4d93-bc4f-899064fa6807" />

example 3
before the pr, a geneticist id would take wallet priority over a chemist id (for instance)


priority used to tally up how many 'command/secure access' areas on the ID, rather than simply sort order.
for reference, these were the areas:
`ACCESS_AI_UPLOAD, ACCESS_ALL_PERSONAL_LOCKERS,  ACCESS_ARMORY, ACCESS_CHANGE_IDS, ACCESS_COMMAND, ACCESS_EVA, ACCESS_KEYCARD_AUTH, ACCESS_MINISAT, ACCESS_RC_ANNOUNCE, ACCESS_TCOMMS, ACCESS_TECH_STORAGE, ACCESS_TELEPORTER, ACCESS_VAULT`

ACCESS_FLAG_COMMAND -> ACCESS_FLAG_PRV_COMMAND
so now it only checks if you have specifically head of staff access instead

## Why It's Good For The Game

- player friendly
- previously lead to wallet tediousness and unpredictability
- make the core functionality and purpose of wallets simple and easy to understand
- the previous functionality was more unpredictable and confusing when considering low pop granting extra access to IDs


## Changelog

:cl: ArchBTW
qol: Changes Wallet Priority: Standard ID cards now go in order properly: from left to right
/:cl:
