### PR TITLE
[TG Mirror] Display slowest unit tests in CL [MDB IGNORE]

### DIFF
--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -18,6 +18,8 @@ GLOBAL_LIST_EMPTY(unit_test_mapping_logs)
 /// Global assoc list of required mapping items, [item typepath] to [required item datum].
 GLOBAL_LIST_EMPTY(required_map_items)
 
+GLOBAL_LIST_EMPTY(test_run_times)
+
 /// A list of every test that is currently focused.
 /// Use the PERFORM_ALL_TESTS macro instead.
 GLOBAL_VAR_INIT(focused_tests, focused_tests())
@@ -237,6 +239,8 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 			log_test(message)
 
 		test_output_desc += " [duration / 10]s"
+		if(duration > 10)
+			GLOB.test_run_times[test_path] = duration
 		if (test.succeeded)
 			log_world("[TEST_OUTPUT_GREEN("PASS")] [test_output_desc]")
 
@@ -393,6 +397,12 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 		CHECK_TICK //We check tick first because the unit test we run last may be so expensive that checking tick will lock up this loop forever
 		RunUnitTest(unit_path, test_results)
 	SSticker.delay_end = FALSE
+
+	log_world("::group::Expensive Unit Test Times")
+	sortTim(GLOB.test_run_times, cmp = GLOBAL_PROC_REF(cmp_numeric_dsc), associative = TRUE)
+	for(var/type, duration in GLOB.test_run_times)
+		log_world("[type] took [duration/10]s")
+	log_world("::endgroup::")
 
 	var/file_name = "data/unit_tests.json"
 	fdel(file_name)


### PR DESCRIPTION
Original PR: 93587
-----
## About The Pull Request
Compiles and displays a sorted list of unit times by run length at the end of all the unit tests.

<img width="679" height="617" alt="image" src="https://github.com/user-attachments/assets/e3788de4-b58a-40f3-b7de-29695fc7b1f6" />
<img width="550" height="744" alt="image" src="https://github.com/user-attachments/assets/6d794c07-9983-4250-bdcf-4ad07c737d47" />


Right now its just if its longer then 1 second but I could make it break after like 10 entries.
## Why It's Good For The Game
Makes it way easier to spot ABNORMALLY slow unit tests. I understand that there is not a ton of optimization that can be made for some of these.
## Changelog
N/A
