### PR TITLE
[TG Mirror] [NO GBP]Fixes some wall mounted items & Flaky poster sign CI Failures [MDB IGNORE]

### DIFF
--- a/code/datums/components/wall_mounted.dm
+++ b/code/datums/components/wall_mounted.dm
@@ -41,6 +41,7 @@
  */
 /datum/component/wall_mounted/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
+
 	if (parent in view(user.client?.view || world.view, user))
 		examine_list += span_notice("\The [hanging_wall_turf] is currently supporting [span_bold("[parent]")]. Deconstruction or excessive damage would cause it to [span_bold("fall to the ground")].")
 

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -39,9 +39,12 @@
 		return
 	RegisterSignal(current_area, COMSIG_AREA_POWER_CHANGE, PROC_REF(AreaPowerCheck))
 	GLOB.intercoms_list += src
+<<<<<<< HEAD
 	if(!unscrewed)
 		find_and_hang_on_wall(directional = TRUE, \
 			custom_drop_callback = CALLBACK(src, PROC_REF(knock_down)))
+=======
+>>>>>>> 5a31b00b2f9 ([NO GBP]Fixes some wall mounted items & Flaky poster sign CI Failures (#93606))
 
 /obj/item/radio/intercom/Destroy()
 	. = ..()

--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -131,7 +131,6 @@
 		unwrenched_sign.sign_path = type
 		unwrenched_sign.set_custom_materials(custom_materials) //This is here so picture frames and wooden things don't get messed up.
 		unwrenched_sign.is_editable = is_editable
-	unwrenched_sign.update_integrity(get_integrity()) //Transfer how damaged it is.
 	unwrenched_sign.setDir(dir)
 	qdel(src) //The sign structure on the wall goes poof and only the sign item from unwrenching remains.
 

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -173,28 +173,13 @@
 	//. += NAMEOF(src, locked)
 	return .
 
-/obj/machinery/power/apc/Initialize(mapload, ndir)
+/obj/machinery/power/apc/Initialize(mapload)
 	. = ..()
+	setDir(dir)
 	//APCs get added to their own processing tasks for the machines subsystem.
 	if (!(datum_flags & DF_ISPROCESSING))
 		datum_flags |= DF_ISPROCESSING
 		SSmachines.processing_apcs += src
-
-	//Pixel offset its appearance based on its direction
-	dir = ndir
-	switch(dir)
-		if(NORTH)
-			offset_old = pixel_y
-			pixel_y = APC_PIXEL_OFFSET
-		if(SOUTH)
-			offset_old = pixel_y
-			pixel_y = -APC_PIXEL_OFFSET
-		if(EAST)
-			offset_old = pixel_x
-			pixel_x = APC_PIXEL_OFFSET
-		if(WEST)
-			offset_old = pixel_x
-			pixel_x = -APC_PIXEL_OFFSET
 
 	var/image/hud_image = image(icon = 'icons/mob/huds/hud.dmi', icon_state = "apc_hacked")
 	hud_image.pixel_w = pixel_x
@@ -276,6 +261,22 @@
 	if(terminal)
 		disconnect_terminal()
 	return ..()
+
+/obj/machinery/power/apc/setDir(newdir)
+	. = ..()
+	switch(newdir)
+		if(NORTH)
+			offset_old = pixel_y
+			pixel_y = APC_PIXEL_OFFSET
+		if(SOUTH)
+			offset_old = pixel_y
+			pixel_y = -APC_PIXEL_OFFSET
+		if(EAST)
+			offset_old = pixel_x
+			pixel_x = APC_PIXEL_OFFSET
+		if(WEST)
+			offset_old = pixel_x
+			pixel_x = -APC_PIXEL_OFFSET
 
 /obj/machinery/power/apc/on_saboteur(datum/source, disrupt_duration)
 	. = ..()

--- a/code/modules/power/lighting/light_construct.dm
+++ b/code/modules/power/lighting/light_construct.dm
@@ -148,6 +148,7 @@
 					if("bulb")
 						new_light = new /obj/machinery/light/small/built(loc)
 				new_light.setDir(dir)
+				new_light.find_and_hang_on_wall()
 				transfer_fingerprints_to(new_light)
 				if(!QDELETED(cell))
 					new_light.cell = cell


### PR DESCRIPTION
Original PR: 93606
-----
## About The Pull Request
- Fixes hand crafted station intercoms not getting deconstructed when the wall is destroyed
- Fixes light fixtures not applying the wall mounted component on completed light frames
- Fixed APC offsets
- Fixes poster signs dropped from destroyed poster structures having 0 integrity
  - Closes #93615
  - Closes #93628
  - Closes #93630
  - Closes #93632
  - Closes #93633

## Changelog
:cl:
fix: hand crafted station intercoms now get deconstructed when the wall is destroyed
fix: light fixtures applying the wall mounted component on completed light frames
fix: APC offsets are correct
fix: poster signs dropped from paintings again have positive integrity and will get destroyed properly
/:cl:

