### PR TITLE
[TG Mirror] Bears are fast mounts [MDB IGNORE]

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -424,6 +424,7 @@
 		COOLDOWN_START(src, pony_trot_cooldown, 500 MILLISECONDS)
 
 /datum/component/riding/creature/bear
+	vehicle_move_delay = 1.5
 
 /datum/component/riding/creature/bear/get_rider_offsets_and_layers(pass_index, mob/offsetter)
 	return list(


### PR DESCRIPTION
Original PR: 93591
-----

## About The Pull Request

Bears are now fast mounts in line with ponies and golden raptors. 

## Why It's Good For The Game

Most mounts speed up when ridden because we insist on making basics mobs slow as balls. 

Space bears are one of few mobs that actually move at a normal human 1.5 second move delay. 

One of the quirks of bear riding is that only sentient bears are ridiable unlike most mounts, where you can tame the NPC mob and ride it.

Sentient bears have suffered greatly in the recent years, they used to attack with a normal 0.8 second delay and be stun immune. 

Now they attack with a 2 second delay like AI controlled bears, can be stunned with stamina damage and even flashed. 

Most competing mounts have a value add in some form, most comparable is the carps and space shark which also share the poor HP pool and spaceproofness of the bear but have big advantages of being able to fly and regenerate.

By making bears fast, we make creating sentient bears inhabit an attractive niche. 

## Changelog

:cl:
balance:  Sentient bears are now fast mounts equal to ponies and yellow raptors.
/:cl:

