### PR TITLE
[TG Mirror] Fixes the syndicate rebar quiver reload action not working [MDB IGNORE]

### DIFF
--- a/code/datums/storage/subtypes/bags.dm
+++ b/code/datums/storage/subtypes/bags.dm
@@ -232,7 +232,7 @@
 	. = ..()
 	set_holdable(/obj/item/ammo_casing/harpoon)
 
-///Rebar quiber bag
+///Rebar quiver bag
 /datum/storage/bag/rebar_quiver
 	max_specific_storage = WEIGHT_CLASS_TINY
 	max_slots = 10

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -563,7 +563,7 @@
 		return
 
 	var/obj/item/ammo_casing/rebar/ammo_to_load = contents[1]
-	held_crossbow.attackby(ammo_to_load, user)
+	held_crossbow.item_interaction(user, ammo_to_load)
 
 /obj/item/storage/bag/quiver
 	name = "quiver"


### PR DESCRIPTION
Original PR: 93614
-----

## About The Pull Request
It works now, I couldn't find what the problem was though.
## Why It's Good For The Game
Fix
## Changelog
:cl:
fix: The syndicate rebar crossbow quiver's action button now functions correctly.
/:cl:
