### PR TITLE
[TG Mirror] Adds a examine tag for reskinnable items. [MDB IGNORE]

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -458,6 +458,9 @@
 	else if (siemens_coefficient <= 0.5)
 		.["partially insulated"] = "It is made from a poor insulator that will dampen (but not fully block) electric shocks passing through it."
 
+	if(LAZYLEN(unique_reskin) && !current_skin)
+		.["reskinnable"] = "This item is able to be reskinned! Alt-Click to do so!"
+
 /obj/item/examine_descriptor(mob/user)
 	return "item"
 


### PR DESCRIPTION
Original PR: 93638
-----

## About The Pull Request

<img width="552" height="117" alt="image" src="https://github.com/user-attachments/assets/dbd3f63f-9977-4973-b6c0-a169776f53e0" />

## Why It's Good For The Game

Things should be known. Thanks to Tonty for handholding me through this.

## Changelog
:cl: 
qol: Reskinnable items now have a 
/:cl:
