### PR TITLE
[TG Mirror] Moves some pipes and cables around on meta, fixes air and power line break [MDB IGNORE]

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -640,6 +640,8 @@
 	name = "Quartermaster Junction"
 	},
 /obj/effect/mapping_helpers/mail_sorting/supply/qm_office,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "alE" = (
@@ -1556,6 +1558,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"aDs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "aDA" = (
 /obj/machinery/light/small/directional/south,
 /obj/item/folder,
@@ -4516,6 +4524,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "bCO" = (
@@ -7201,9 +7210,6 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/surgery/aft)
 "cAf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8742,10 +8748,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "deD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "deG" = (
@@ -9743,7 +9749,6 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "dve" = (
-/obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/recharge_station,
 /turf/open/floor/plating,
@@ -11119,6 +11124,8 @@
 /area/station/service/bar)
 "dVb" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "dVc" = (
@@ -14344,6 +14351,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "eXj" = (
@@ -15869,6 +15878,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+<<<<<<< HEAD
+=======
+"fyA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
+>>>>>>> 796c09d6176 (Moves some pipes and cables around on meta, fixes air and power line break (#93601))
 "fyJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -16937,11 +16955,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "fVt" = (
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "fVA" = (
@@ -23074,11 +23093,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "iar" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "ias" = (
@@ -23740,6 +23759,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"ilF" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "ilJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -24884,6 +24910,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"iFl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "iFz" = (
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -25044,10 +25078,11 @@
 /area/station/service/chapel)
 "iIE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "iIP" = (
@@ -26350,6 +26385,7 @@
 "jdQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "jdR" = (
@@ -27967,6 +28003,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"jED" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "jEI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -31139,6 +31183,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "kIY" = (
@@ -31609,7 +31656,6 @@
 "kPZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "kQe" = (
@@ -32212,7 +32258,6 @@
 /area/station/service/chapel)
 "lah" = (
 /obj/structure/rack,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
@@ -37158,13 +37203,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
-"mPH" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/aft/greater)
 "mPK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41420,11 +41458,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmospherics_engine)
 "ool" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "oor" = (
@@ -54666,12 +54704,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "sPO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "sPV" = (
@@ -55416,10 +55452,6 @@
 /obj/structure/plasticflaps/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"tbI" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/aft)
 "tbK" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
@@ -61190,8 +61222,11 @@
 "uYD" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
+<<<<<<< HEAD
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+=======
+>>>>>>> 796c09d6176 (Moves some pipes and cables around on meta, fixes air and power line break (#93601))
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "uYE" = (
@@ -89824,7 +89859,7 @@ dwH
 fUr
 fUr
 fUr
-fUr
+ilF
 bkJ
 iIE
 cAf
@@ -90597,8 +90632,8 @@ ieD
 gnR
 ggW
 jXu
-fpn
-knQ
+siY
+sHu
 bPM
 sHu
 mkz
@@ -90652,6 +90687,7 @@ kJx
 lIa
 xjC
 pOa
+<<<<<<< HEAD
 uOH
 pOa
 pOa
@@ -90660,6 +90696,16 @@ jUb
 jUb
 jUb
 hfi
+=======
+jED
+fyA
+gSt
+jGZ
+lYG
+uiM
+nVq
+dIK
+>>>>>>> 796c09d6176 (Moves some pipes and cables around on meta, fixes air and power line break (#93601))
 jUb
 jUb
 sSp
@@ -90693,7 +90739,7 @@ oxj
 sbs
 tSw
 lah
-mPH
+vUM
 fje
 jgW
 tSw
@@ -107067,9 +107113,9 @@ dEr
 ckW
 aly
 qXB
-edC
-psZ
-wzK
+eYj
+wrn
+iFl
 tCS
 xww
 hht
@@ -107324,7 +107370,7 @@ dkh
 vcb
 bjD
 qXB
-kbo
+gnk
 tbd
 fVt
 tCS
@@ -108414,7 +108460,7 @@ nPJ
 gLi
 xuD
 xuD
-xuD
+aDs
 jdQ
 uSM
 bLd
@@ -108671,7 +108717,7 @@ mEL
 sCM
 clj
 uGX
-tbI
+fPD
 deD
 xuD
 xuD


### PR DESCRIPTION
Original PR: 93601
-----
## About The Pull Request

Moves some pipes and cables around on Metastation, so that they're more consistently built (like a place where they could place air and cables on top of disposals with no obstacles, but don't). several places seem to not follow the same layout criteria as the rest, for reasons I can't see. 
Also, there was a place under the library where the air pipe and power cables should be connecting, but aren't, so those are fixed.

## Why It's Good For The Game

Removes two power cables and one air pipe that were unnecessary, meeting and exceeding Nanotrasen's "Sustainable Solutions" pledges for the next two centuries.
More predictable pipe placement
Connected pipes and wires

## Changelog
:cl:

map: Meta's pipe and wire placements are more predictable
fix: Meta's pipes and wires below library are connected again

/:cl:
