### PR TITLE
[TG Mirror] valid_subtypes proc [MDB IGNORE]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -196,6 +196,9 @@
 /code/modules/atmospherics/ @Pickle-Coding
 /code/modules/power/ @Pickle-Coding
 
+# FalloutFalcon
+/code/__HELPERS/abstract_types.dm @FalloutFalcon
+/code/__HELPERS/random_items.dm @FalloutFalcon
 
 # MULTIPLE OWNERS
 

--- a/code/__HELPERS/abstract_types.dm
+++ b/code/__HELPERS/abstract_types.dm
@@ -1,0 +1,14 @@
+/// Returns a list of all abstract typepaths for all datums
+/proc/get_abstract_types()
+	var/static/list/abstracts
+	if(abstracts)
+		return abstracts
+	abstracts = list()
+	for(var/datum/sometype as anything in subtypesof(/datum))
+		if(sometype == sometype::abstract_type)
+			abstracts |= sometype::abstract_type
+	return abstracts
+
+/// Like subtypesof, but automatically excludes abstract typepaths
+/proc/valid_subtypesof(datum/sometype)
+	return subtypesof(sometype) - get_abstract_types()

--- a/code/_globalvars/lists/cargo.dm
+++ b/code/_globalvars/lists/cargo.dm
@@ -22,7 +22,6 @@ GLOBAL_LIST_EMPTY(supplypod_loading_bays)
 /// Called when the global exports_list is empty, and sets it up.
 /proc/init_Exports()
 	var/list/exports = list()
-	for(var/datum/export/subtype as anything in subtypesof(/datum/export))
-		if(subtype::abstract_type != subtype)
-			exports += new subtype
+	for(var/datum/export/subtype as anything in valid_subtypesof(/datum/export))
+		exports += new subtype
 	return exports

--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -119,9 +119,7 @@ GLOBAL_LIST_INIT(blood_types, init_blood_types())
 /// Initializes the list of blood type singletons
 /proc/init_blood_types()
 	. = list()
-	for(var/datum/blood_type/blood_type_path as anything in subtypesof(/datum/blood_type))
-		if(blood_type_path::abstract_type == blood_type_path) // Don't instantiate abstract blood types
-			continue
+	for(var/datum/blood_type/blood_type_path as anything in valid_subtypesof(/datum/blood_type))
 		var/datum/blood_type/new_type = new blood_type_path()
 		.[new_type.id] = new_type
 

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -157,10 +157,8 @@
 	var/list/_entries_by_type = list()
 	entries_by_type = _entries_by_type
 
-	for(var/I in typesof(/datum/config_entry)) //typesof is faster in this case
+	for(var/I in valid_subtypesof(/datum/config_entry)) //typesof is faster in this case
 		var/datum/config_entry/E = I
-		if(initial(E.abstract_type) == I)
-			continue
 		E = new I
 		var/esname = E.name
 		var/datum/config_entry/test = _entries[esname]

--- a/code/controllers/subsystem/processing/instruments.dm
+++ b/code/controllers/subsystem/processing/instruments.dm
@@ -36,10 +36,8 @@ PROCESSING_SUBSYSTEM_DEF(instruments)
 	songs -= S
 
 /datum/controller/subsystem/processing/instruments/proc/initialize_instrument_data()
-	for(var/path in subtypesof(/datum/instrument))
+	for(var/path in valid_subtypesof(/datum/instrument))
 		var/datum/instrument/I = path
-		if(initial(I.abstract_type) == path)
-			continue
 		I = new path
 		I.Initialize()
 		if(!I.id)

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -94,15 +94,12 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 		return
 
-	for(var/datum/station_trait/trait_typepath as anything in subtypesof(/datum/station_trait))
+	for(var/datum/station_trait/trait_typepath as anything in valid_subtypesof(/datum/station_trait))
 
 		// If forced, (probably debugging), just set it up now, keep it out of the pool.
 		if(initial(trait_typepath.force))
 			setup_trait(trait_typepath)
 			continue
-
-		if(initial(trait_typepath.abstract_type) == trait_typepath)
-			continue //Dont add abstract ones to it
 
 		if(!(initial(trait_typepath.trait_flags) & STATION_TRAIT_PLANETARY) && SSmapping.is_planetary()) // we're on a planet but we can't do planet ;_;
 			continue

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -87,9 +87,13 @@
 
 	/**
 	 * Parent types.
-	 *
-	 * Use path Ex:(abstract_type = /obj/item). Generally for abstract code objects, atoms with a set abstract_type can never be selected by spawner.
-	 * These should be things that should never show up in a round, this does not include things that require init behavoir to function.
+	 * 
+	 * Abstract-ness is a meta-property of a class that is used to indicate
+	 * that the class is intended to be used as a base class for others, and
+	 * should not (or cannot) be instantiated.
+	 * We have no such language concept in DM, and so we provide a datum member
+	 * that can be used to hint at abstractness for circumstances where we would
+	 * like that to be the case, such as base behavior providers.
 	 */
 	var/abstract_type = /datum
 

--- a/code/datums/station_traits/admin_panel.dm
+++ b/code/datums/station_traits/admin_panel.dm
@@ -28,9 +28,7 @@ ADMIN_VERB(station_traits_panel, R_FUN, "Modify Station Traits", "Modify the sta
 
 	var/list/valid_station_traits = list()
 
-	for (var/datum/station_trait/station_trait_path as anything in subtypesof(/datum/station_trait))
-		if(station_trait_path::abstract_type == station_trait_path)
-			continue
+	for (var/datum/station_trait/station_trait_path as anything in valid_subtypesof(/datum/station_trait))
 		valid_station_traits += list(list(
 			"name" = initial(station_trait_path.name),
 			"path" = station_trait_path,

--- a/code/modules/autowiki/pages/stockparts.dm
+++ b/code/modules/autowiki/pages/stockparts.dm
@@ -18,11 +18,7 @@
 /datum/autowiki/stock_parts/generate()
 	var/output = ""
 
-	for(var/part_type in subtypesof(/obj/item/stock_parts))
-		var/obj/item/stock_parts/type_to_check = part_type
-		if(initial(type_to_check.abstract_type) == part_type)
-			continue
-
+	for(var/part_type in valid_subtypesof(/obj/item/stock_parts))
 		if(!battery_whitelist.Find(part_type) && ispath(part_type, /obj/item/stock_parts/power_store))
 			continue
 

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -50,17 +50,13 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 
 /proc/init_preference_entries()
 	var/list/output = list()
-	for (var/datum/preference/preference_type as anything in subtypesof(/datum/preference))
-		if (initial(preference_type.abstract_type) == preference_type)
-			continue
+	for (var/datum/preference/preference_type as anything in valid_subtypesof(/datum/preference))
 		output[preference_type] = new preference_type
 	return output
 
 /proc/init_preference_entries_by_key()
 	var/list/output = list()
-	for (var/datum/preference/preference_type as anything in subtypesof(/datum/preference))
-		if (initial(preference_type.abstract_type) == preference_type)
-			continue
+	for (var/datum/preference/preference_type as anything in valid_subtypesof(/datum/preference))
 		output[initial(preference_type.savefile_key)] = GLOB.preference_entries[preference_type]
 	return output
 

--- a/code/modules/explorer_drone/exploration_site.dm
+++ b/code/modules/explorer_drone/exploration_site.dm
@@ -118,10 +118,8 @@ GLOBAL_LIST_EMPTY(exploration_sites)
 
 /datum/exploration_site/proc/build_exploration_event_requirements_cache()
 	. = list()
-	for(var/event_type in subtypesof(/datum/exploration_event))
+	for(var/event_type in valid_subtypesof(/datum/exploration_event))
 		var/datum/exploration_event/event = event_type
-		if(initial(event.abstract_type) == event_type)
-			continue
 		event = new event_type
 		.[event_type] = list("required" = event.required_site_traits,"blacklisted" = event.blacklisted_site_traits)
 		//Should be no event refs,GC'd naturally

--- a/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
+++ b/code/modules/mob/living/basic/lavaland/raptor/raptor_egg.dm
@@ -23,14 +23,14 @@
 			continue
 		add_growth_component(path)
 		return
-	var/list/valid_subtypes = list()
+	var/list/valid_subtypesof = list()
 	var/static/list/all_subtypes = subtypesof(/mob/living/basic/raptor/baby_raptor)
 	for(var/path in all_subtypes)
 		var/mob/living/basic/raptor/baby_raptor/raptor_path = path
 		if(!prob(initial(raptor_path.roll_rate)))
 			continue
-		valid_subtypes += raptor_path
-	add_growth_component(pick(valid_subtypes))
+		valid_subtypesof += raptor_path
+	add_growth_component(pick(valid_subtypesof))
 
 /obj/item/food/egg/raptor_egg/proc/add_growth_component(growth_path)
 	if(length(GLOB.raptor_population) >= MAX_RAPTOR_POP)

--- a/code/modules/unit_tests/cargo_selling.dm
+++ b/code/modules/unit_tests/cargo_selling.dm
@@ -18,9 +18,7 @@
 	export_types = list(/obj/item/cargo_unit_test_content)
 
 /datum/unit_test/cargo_selling/Run()
-	for(var/datum/export/subtype as anything in subtypesof(/datum/export))
-		if(subtype::abstract_type == subtype)
-			continue
+	for(var/datum/export/subtype as anything in valid_subtypesof(/datum/export))
 		if(subtype::k_recovery_time < SSprocessing.wait)
 			TEST_FAIL("[subtype] should have k_recovery time >= [SSprocessing.wait]")
 		var/datum/export/sell = new subtype

--- a/code/modules/unit_tests/trauma_granting.dm
+++ b/code/modules/unit_tests/trauma_granting.dm
@@ -18,10 +18,7 @@
 	// Requires a obsession target
 	trauma_blacklist += typesof(/datum/brain_trauma/special/obsessed)
 
-	for(var/datum/brain_trauma/trauma as anything in typesof(/datum/brain_trauma) - trauma_blacklist)
-		if(trauma == initial(trauma.abstract_type))
-			continue
-
+	for(var/datum/brain_trauma/trauma as anything in valid_subtypesof(/datum/brain_trauma) - trauma_blacklist)
 		test_trauma(dummy, trauma)
 
 /datum/unit_test/trauma_granting/proc/test_trauma(mob/living/carbon/human/dummy, trauma)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -418,6 +418,7 @@
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\_planes.dm"
 #include "code\__HELPERS\_string_lists.dm"
+#include "code\__HELPERS\abstract_types.dm"
 #include "code\__HELPERS\admin.dm"
 #include "code\__HELPERS\ai.dm"
 #include "code\__HELPERS\announcements.dm"


### PR DESCRIPTION
Original PR: 93541
-----
## About The Pull Request
discussed in #93439, a generic proc for getting a list of all types minus abstract types.
applies this to most instances of a for loop that currently filters out abstract types

iffy on the name, not sure if i should be more verbose with its relation to abstract types or have `of` at the end of it like how `subtypesof` is

also unsure if its better to have it as `typesof` or `subtypesof` I cant think of many instances where typesof goes awry and subtypes of means if i were to replace something like
```
	for(var/obj/item/iter_type as anything in typesof(requested_type))
		if((iter_type.abstract_type == iter_type) || (iter_type.item_flags & ABSTRACT))
			continue
```
the behavoir would acctually change if the datum its using happens to actually be valid (because there is still some random items where the base type is acctually real)

however `|=` seems to be the best way of compling the list based on 
<img width="727" height="177" alt="image" src="https://github.com/user-attachments/assets/8300a850-6fc3-4ce4-957c-059ccd3071e4" />


it SHOULD be a nothing burger for performance, however I have not bench marked the difference. (also testing, there is a total of 7 calls in init to it)
## Why It's Good For The Game
more consistant way of filtering out abstract types then having to do it for every relevent for loop by hand
## Changelog
N/A, I hope.....
