### PR TITLE
[TG Mirror] Prevents sealed-looking containers from spilling. [MDB IGNORE]

### DIFF
--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -413,6 +413,7 @@
 	name = "condiment pack"
 	desc = "A small plastic pack with condiments to put on your food."
 	icon_state = "condi_empty"
+	initial_reagent_flags = parent_type::initial_reagent_flags | NO_SPLASH
 	volume = 10
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(10)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -11,7 +11,7 @@
 	volume = 30
 	possible_transfer_amounts = list(5)
 	resistance_flags = ACID_PROOF
-	initial_reagent_flags = OPENCONTAINER
+	initial_reagent_flags = OPENCONTAINER | NO_SPLASH
 	slot_flags = ITEM_SLOT_BELT
 	var/ignore_flags = NONE
 	var/infinite = FALSE

--- a/code/modules/reagents/reagent_containers/inhaler.dm
+++ b/code/modules/reagents/reagent_containers/inhaler.dm
@@ -216,7 +216,7 @@
 	icon = 'icons/obj/medical/chemical.dmi'
 	icon_state = "canister_generic"
 
-	initial_reagent_flags = SEALED_CONTAINER|DRAINABLE|REFILLABLE
+	initial_reagent_flags = SEALED_CONTAINER | DRAINABLE | REFILLABLE | NO_SPLASH
 	has_variable_transfer_amount = FALSE
 
 	max_integrity = 60

--- a/code/modules/reagents/reagent_containers/medigel.dm
+++ b/code/modules/reagents/reagent_containers/medigel.dm
@@ -9,7 +9,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	item_flags = NOBLUDGEON
 	obj_flags = UNIQUE_RENAME
-	initial_reagent_flags = OPENCONTAINER
+	initial_reagent_flags = OPENCONTAINER | NO_SPLASH
 	slot_flags = ITEM_SLOT_BELT
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -8,7 +8,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	item_flags = NOBLUDGEON
-	initial_reagent_flags = OPENCONTAINER
+	initial_reagent_flags = OPENCONTAINER | NO_SPLASH
 	slot_flags = ITEM_SLOT_BELT
 	throwforce = 0
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
Original PR: 93649
-----

## About The Pull Request
Fixes a logical inconsistency with several types of containers that are **functionally open** for game mechanics (allowing refilling, transfer, etc.) but are **perceived as closed** from a user perspective.
## Why It's Good For The Game
your ketchup won't magically spill from a sealed packet anymore when thrown.
## Changelog
:cl:
fix: Containers that appear sealed (spray bottles, hyposprays, gel cans, condiment packets, inhaler cartridges) no longer spill when thrown or poured out.
/:cl:
