### PR TITLE
[TG Mirror] Prevents post-slip events happening without slipping [MDB IGNORE]

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -1,10 +1,12 @@
 /mob/living/carbon/slip(knockdown_amount, obj/slipped_on, lube_flags, paralyze, daze, force_drop = FALSE)
 	if(movement_type & MOVETYPES_NOT_TOUCHING_GROUND)
 		return FALSE
+	if(!(loc.handle_slip(src, knockdown_amount, slipped_on, lube_flags, paralyze, daze, force_drop)))
+		return FALSE
 	if(!(lube_flags & SLIDE_ICE))
 		log_combat(src, (slipped_on || get_turf(src)), "slipped on the", null, ((lube_flags & SLIDE) ? "(SLIDING)" : null))
 	..()
-	return loc.handle_slip(src, knockdown_amount, slipped_on, lube_flags, paralyze, daze, force_drop)
+	return TRUE
 
 /mob/living/carbon/Move(NewLoc, direct)
 	. = ..()


### PR DESCRIPTION
Original PR: 93653
-----
## About The Pull Request

Moves the logging and parent call within `/carbon/slip()` to only happen after `handle_slip()` has succeeded

## Why It's Good For The Game

Prevents these things from happening while safely walking or crawling over potentially slippable surfaces:
Your brain falling out of your head
Your hat falling off your `hat_stabilizer` parent
You getting a mood event
Onlookers getting a mood event
A slip getting sent to the logs

## Changelog
:cl:

fix: Prevents post-slip events such as hats falling off from occurring while crawling over slips.

/:cl:
