### PR TITLE
[TG Mirror] wave of desperation desc doesn't say it sleeps you anymore [MDB IGNORE]

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/side_knowledge/tier_two.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_knowledge/tier_two.dm
@@ -60,8 +60,7 @@
 /datum/heretic_knowledge/spell/opening_blast
 	name = "Wave Of Desperation"
 	desc = "Grants you Wave Of Desparation, a spell which can only be cast while restrained. \
-		It removes your restraints, repels and knocks down adjacent people, and applies the Mansus Grasp to everything nearby. \
-		However, you will fall unconscious a short time after casting this spell."
+		It removes your restraints, repels and knocks down adjacent people, and applies the Mansus Grasp to everything nearby."
 	gain_text = "My shackles undone in dark fury, their feeble bindings crumble before my power."
 
 	action_to_add = /datum/action/cooldown/spell/aoe/wave_of_desperation

--- a/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
+++ b/code/modules/antagonists/heretic/magic/wave_of_desperation.dm
@@ -1,7 +1,7 @@
 /datum/action/cooldown/spell/aoe/wave_of_desperation
 	name = "Wave Of Desperation"
 	desc = "Removes your restraints, repels and knocks down adjacent people, and applies certain effects of the Mansus Grasp upon everything nearby. \
-		Cannot be cast unless you are restrained, and the stress renders you unconscious 12 seconds later! (Can be casted without a focus)"
+		Cannot be cast unless you are restrained. (Can be casted without a focus)"
 	background_icon_state = "bg_heretic"
 	overlay_icon_state = "bg_heretic_border"
 	button_icon = 'icons/mob/actions/actions_ecult.dmi'

--- a/code/modules/antagonists/heretic/status_effects/buffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/buffs.dm
@@ -379,12 +379,12 @@
 
 /atom/movable/screen/alert/status_effect/heretic_lastresort
 	name = "Last Resort"
-	desc = "Your head spins, heart pumping as fast as it can, losing the fight with the ground. Run to safety!"
+	desc = "Your head spins, heart pumping as fast as it can!"
 	icon_state = "lastresort"
 
 /datum/status_effect/heretic_lastresort/on_apply()
 	ADD_TRAIT(owner, TRAIT_IGNORESLOWDOWN, TRAIT_STATUS_EFFECT(id))
-	to_chat(owner, span_userdanger("You won't give up that easily! Run to safety!"))
+	to_chat(owner, span_userdanger("You won't give up that easily!"))
 	return TRUE
 
 /datum/status_effect/heretic_lastresort/on_remove()


### PR DESCRIPTION
Original PR: 93637
-----

## About The Pull Request
wave of desperation doesn't sleep you anymore, the description for the spell wasn't changed
## Why It's Good For The Game
this spell doesn't knock you out anymore (before and after heretic rework pr)
<img width="1152" height="797" alt="image" src="https://github.com/user-attachments/assets/354c111d-534a-4b15-80cc-1ab16e298da9" />

## Changelog
:cl:
spellcheck: wave of desperation description does not state it sleeps you anymore
/:cl:
