### PR TITLE
[TG Mirror] Birdshot plaque was killed and moved to old stations list, new Catwalk plaque [MDB IGNORE]

### DIFF
--- a/code/game/objects/structures/plaques/static_plaques.dm
+++ b/code/game/objects/structures/plaques/static_plaques.dm
@@ -38,9 +38,9 @@
 
 //Current stations
 
-// Birdshot: added Apr 29, 2023 (#74371)
-/obj/structure/plaque/static_plaque/golden/commission/birdshot
-	desc = "Spinward Sector Station SS-13\n'Birdshot' Class Outpost\nCommissioned 29/04/2563\n'Shooting for the Stars'"
+// Catwalk: added Apr 10, 2025 (#90532)
+/obj/structure/plaque/static_plaque/golden/commission/catwalk
+	desc = "Spinward Sector Station SS-13\n'Catwalk' Class Outpost\nCommissioned 10/04/2565\n'The New Level'"
 
 // Deltastation: added Dec 17, 2016 (#22066)
 /obj/structure/plaque/static_plaque/golden/commission/delta
@@ -123,6 +123,10 @@
 // Uterusstation: added Sep 03, 2011 (bbd6db9ce2d6341892b89a620593fc8877f5a817), removed Jun 21, 2012 (72d72f7ce522c2d2ad4863f44ee9f5054413c489)- 9 months, 18 days
 /obj/structure/plaque/static_plaque/golden/commission/uterus
 	desc = "Spinward Sector Station SS-01\n'Uterus' Class Outpost\nCommissioned 03/09/2551\nDecommissioned 21/06/2552\n'Humanity's Vanguard'"
+
+// Birdshot: added Apr 29, 2023 (#74371), removed Jul 9, 2025 (#92022) — 2 years, 2 months, 10 days
+/obj/structure/plaque/static_plaque/golden/commission/birdshot
+	desc = "Spinward Sector Station SS-13\n'Birdshot' Class Outpost\nCommissioned 29/04/2563\nDecommissioned 09/07/2565\n'Shooting for the Stars'"
 
 // Other Stations
 


### PR DESCRIPTION
Original PR: 93576
-----
## About The Pull Request

title, ALSO please someone map it in-game later because im lazy
catwalk author words:
<img width="258" height="119" alt="image" src="https://github.com/user-attachments/assets/43506a5f-124d-49cc-a02f-ebd101ffc33b" />


## Why It's Good For The Game

idk consistency

## Changelog

:cl:
spellcheck: Birdshot plaque was decomissioned and replaced on Catwalk.
/:cl:
