### PR TITLE
[TG Mirror] Improves debugging for events config + fixes inconsistencies in events.json [MDB IGNORE]

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -8,6 +8,8 @@ SUBSYSTEM_DEF(events)
 	var/list/control = list()
 	///assoc list of all datum/round_event_control, ordered by name. name => event
 	var/list/events_by_name = list()
+	///assoc list of all nonrunning event types, ordered by name. name => event typepath
+	var/list/nonrunning_events_by_name = list()
 	///list of all existing /datum/round_event currently being run.
 	var/list/running = list()
 	///cache of currently running events, for lag checking.
@@ -24,7 +26,10 @@ SUBSYSTEM_DEF(events)
 /datum/controller/subsystem/events/Initialize()
 	for(var/type in typesof(/datum/round_event_control))
 		var/datum/round_event_control/event = new type()
-		if(!event.typepath || !event.valid_for_map())
+		if(!event.typepath)
+			continue
+		if(!event.valid_for_map())
+			nonrunning_events_by_name[event.name] = event.type
 			continue //don't want this one! leave it for the garbage collector
 		control += event //add it to the list of all events (controls)
 		events_by_name[event.name] = event
@@ -49,8 +54,9 @@ SUBSYSTEM_DEF(events)
 	var/list/configuration = json_decode(file2text(json_file))
 	for(var/variable in configuration)
 		var/datum/round_event_control/event = events_by_name[variable]
-		if(!event)
-			stack_trace("Invalid event [event] attempting to be configured.")
+		if(isnull(event))
+			if(isnull(nonrunning_events_by_name[variable])) // don't stack_trace events that aren't running due to map flags
+				stack_trace("Invalid event [variable] attempting to be configured.")
 			continue
 		for(var/event_variable in configuration[variable])
 			if(!(event.vars.Find(event_variable)))

--- a/config/events.json
+++ b/config/events.json
@@ -1,8 +1,4 @@
 {
-	"Space Pirates": {
-		"min_players": 20,
-		"weight": 10
-	},
 	"Spawn Bitrunning Glitch": {
 		"min_players": 1,
 		"weight": 100
@@ -17,7 +13,7 @@
 		"weight": 25
 	},
 	"Brand Intelligence": {
-		"min_players": 20,
+		"min_players": 15,
 		"weight": 5
 	},
 	"Bureaucratic Error": {
@@ -149,10 +145,6 @@
 		"min_players": 0,
 		"weight": 10
 	},
-	"Spider Infestation": {
-		"min_players": 20,
-		"weight": 10
-	},
 	"Stray Cargo Pod": {
 		"min_players": 0,
 		"weight": 20,
@@ -183,7 +175,7 @@
 	},
 	"Ventilation Clog: Major": {
 		"min_players": 0,
-		"weight": 10,
+		"weight": 12,
 		"earliest_start": 6000
 	},
 	"Ventilation Clog: Critical": {
@@ -202,7 +194,7 @@
 	},
 	"Wormholes": {
 		"min_players": 2,
-		"weight": 1
+		"weight": 2
 	},
 	"Anomaly: Energetic Flux": {
 		"min_players": 1,
@@ -248,42 +240,9 @@
 		"min_players": 20,
 		"weight": 10
 	},
-	"Abductors": {
-		"min_players": 20,
-		"weight": 10
-	},
-	"Alien Infestation": {
-		"min_players": 10,
-		"weight": 5
-	},
-	"Blob": {
-		"min_players": 20,
-		"weight": 10
-	},
-	"Changeling Meteor": {
-		"min_players": 20,
-		"weight": 8
-	},
-	"Spawn Fugitives": {
-		"min_players": 20,
-		"weight": 10,
-		"earliest_start": 18000
-	},
-	"Spawn Morph": {
-		"min_players": 0,
-		"weight": 0
-	},
-	"Spawn Nightmare": {
-		"min_players": 20,
-		"weight": 10
-	},
 	"Lone Operative": {
 		"min_players": 0,
 		"weight": 0
-	},
-	"Spawn Revenant": {
-		"min_players": 5,
-		"weight": 7
 	},
 	"Random Human-level Intelligence": {
 		"min_players": 0,
@@ -292,19 +251,6 @@
 	"Station-wide Human-level Intelligence": {
 		"min_players": 0,
 		"weight": 0
-	},
-	"Spawn Slaughter Demon": {
-		"min_players": 20,
-		"weight": 1,
-		"earliest_start": 36000
-	},
-	"Spawn Space Dragon": {
-		"min_players": 20,
-		"weight": 7
-	},
-	"Spawn Space Ninja": {
-		"min_players": 20,
-		"weight": 10
 	},
 	"Immovable Rod": {
 		"min_players": 15,


### PR DESCRIPTION
Original PR: 93595
-----
## About The Pull Request

If an event is not found in the list, it will be null, so the stack trace when there is an invalid one in there will always return "Invalid event attempting to be configured." AKA nothing useful to indicate which event in the config is actually causing the failure.

Also stops stack trace from declaring 'invalid' config when they are simply not loaded due to the current map.

It should be printing out [variable] instead.

Also removes a bunch of non existent events from the events.json and fixes a few inconsistencies with the default weights.

## Why It's Good For The Game

Stack traces with useful information are good.

## Changelog

Nothing player-facing
