### PR TITLE
[TG Mirror] Fixes supermatter anomalies being able to drop anomaly cores. [MDB IGNORE]

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -24,7 +24,7 @@
 	///Chance per second that we will move
 	var/move_chance = ANOMALY_MOVECHANCE
 
-/obj/effect/anomaly/Initialize(mapload, new_lifespan)
+/obj/effect/anomaly/Initialize(mapload, new_lifespan, drops_core = TRUE)
 	. = ..()
 
 	if(!mapload)
@@ -35,6 +35,9 @@
 
 	if (!impact_area)
 		return INITIALIZE_HINT_QDEL
+
+	if(!drops_core)
+		anomaly_core = null
 
 	if(anomaly_core)
 		anomaly_core = new anomaly_core(src)


### PR DESCRIPTION
Original PR: 93611
-----

## About The Pull Request
Readds the drops_core argument for determining whether an anomaly is capable of dropping a core through any means possible.

## Why It's Good For The Game
For intended behaviour of the supermatter.

## Changelog

:cl:
fix: Supermatter anomalies no longer drop anomaly cores.
fix: Fix supermatter flux anomalies from sm delam not emping or whatever.
/:cl:

